### PR TITLE
Add `gh ai run explain` command for GitHub Actions workflow diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ gh ai pr create [GH_PR_CREATE_OPTIONS]
 gh ai pr review [PR_NUMBER] [GH_PR_REVIEW_OPTIONS]
 gh ai pr explain [PR_NUMBER] [--comment | --edit]
 gh ai issue create [-d DESCRIPTION] [GH_ISSUE_CREATE_OPTIONS]
+gh ai run explain <RUN_ID>
 ```
 
 ### Commit
@@ -76,17 +77,26 @@ gh ai issue create -d "Login crash" --label bug --assignee @me
 some_command 2>&1 | gh ai issue create -d "Command X fails" # pipe error context
 ```
 
+### Run
+
+Analyzes a GitHub Actions workflow run and explains what happened.
+
+```bash
+gh ai run explain 123456 # uses --log-failed for failed runs, --log otherwise
+```
+
 ## Configuration
 
 Override the AI provider and model via `gh config`.
 
-| Key                         | Default     | Description                           |
-| --------------------------- | ----------- | ------------------------------------- |
-| `gh-ai.provider`     | `anthropic` | AI provider (`anthropic`)             |
-| `gh-ai.model`        | `haiku`     | Model for all commands (fallback)     |
-| `gh-ai.commit.model` |             | Model override for `commit`           |
+| Key                  | Default     | Description                                   |
+| -------------------- | ----------- | --------------------------------------------- |
+| `gh-ai.provider`     | `anthropic` | AI provider (`anthropic`)                     |
+| `gh-ai.model`        | `haiku`     | Model for all commands (fallback)             |
+| `gh-ai.commit.model` |             | Model override for `commit`                   |
 | `gh-ai.pr.model`     |             | Model override for `pr create/review/explain` |
-| `gh-ai.issue.model`  |             | Model override for `issue create`     |
+| `gh-ai.issue.model`  |             | Model override for `issue create`             |
+| `gh-ai.run.model`    |             | Model override for `run explain`              |
 
 Per-command keys take priority over `gh-ai.model`.
 

--- a/gh-ai
+++ b/gh-ai
@@ -39,6 +39,7 @@ source "$_gh_ai_source_dir/scripts/gh_cmd.sh"
 source "$_gh_ai_source_dir/scripts/gh_commit.sh"
 source "$_gh_ai_source_dir/scripts/gh_pr.sh"
 source "$_gh_ai_source_dir/scripts/gh_issue.sh"
+source "$_gh_ai_source_dir/scripts/gh_run.sh"
 
 # Help function
 #
@@ -55,11 +56,13 @@ COMMANDS:
     pr          Pull request operations (create, review, explain)
     commit      Generate a commit message for staged changes
     issue       Issue operations (create)
+    run         Workflow run operations (explain)
 
 SEE ALSO:
     gh ai pr --help        # PR command help
     gh ai commit --help    # Commit command help
     gh ai issue --help     # Issue command help
+    gh ai run --help       # Run command help
 EOF
 }
 
@@ -78,12 +81,15 @@ main() {
 	issue)
 		_gh_issue "$@"
 		;;
+	run)
+		_gh_run "$@"
+		;;
 	--help | -h | help | "")
 		_show_help
 		;;
 	*)
 		gum log --level error "Unknown command '$command'"
-		gum log --level info "Available commands: pr, commit, issue"
+		gum log --level info "Available commands: pr, commit, issue, run"
 		gum log --level info "Run 'gh ai --help' for usage information"
 		exit 1
 		;;

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+[ -z "${DEBUG:-}" ] || set -x
+
+set -euo pipefail
+
+# Run-related functions for gh-ai
+
+# Extract run ID from arguments
+#
+# Looks for the first numeric argument in the provided args.
+# Returns the run ID or empty string if none found.
+#
+# Example: _get_run_id explain 123456  # Returns: 123456
+_get_run_id() {
+	local args=("$@")
+	local i=0
+
+	while [[ $i -lt ${#args[@]} ]]; do
+		if [[ "${args[$i]}" =~ ^[0-9]+$ ]]; then
+			echo "${args[$i]}"
+			return 0
+		fi
+		((++i))
+	done
+}
+
+# Run help function
+#
+# Displays comprehensive help information for all run subcommands
+# including usage examples and available options.
+_show_run_help() {
+	cat <<'EOF'
+gh ai run - Workflow run commands with AI assistance
+
+USAGE:
+    gh ai run explain <RUN_ID>
+
+DESCRIPTION:
+    Analyzes GitHub Actions workflow runs and explains what happened.
+
+COMMANDS:
+    explain     Analyze a workflow run and explain failures
+
+SEE ALSO:
+    gh ai run explain --help    # Run explain usage
+EOF
+}
+
+# Run Explain implementation
+#
+# Analyzes a GitHub Actions workflow run and generates an AI explanation
+# of what happened, focusing on root cause and actionable fixes.
+# Prints the explanation to stdout.
+#
+# Usage: _gh_run_explain <RUN_ID> [--log] [--log-failed]
+_gh_run_explain() {
+	local args=("$@")
+
+	local template_file
+	# shellcheck disable=SC2154
+	template_file="$_gh_ai_source_dir/templates/gh_run_explain.tmpl"
+
+	local gh_run_id
+	gh_run_id=$(_get_run_id "${args[@]}")
+	if [[ -z "$gh_run_id" ]]; then
+		gum log --level error "No run ID provided"
+		gum log --level info "Usage: gh ai run explain <RUN_ID>"
+		return 1
+	fi
+
+	# Fetch run metadata
+	local gh_run_json
+	gh_run_json=$(gum spin --title "Fetching GitHub workflow run metadata..." -- \
+		gh run view "$gh_run_id" --json displayTitle,conclusion,url,event,headBranch,jobs || true)
+	if [[ -z "$gh_run_json" ]]; then
+		gum log --level error "Failed to fetch run $gh_run_id"
+		return 1
+	fi
+
+	local gh_run_title
+	gh_run_title=$(echo "$gh_run_json" | jq -r '.displayTitle // ""')
+
+	local gh_run_conclusion
+	gh_run_conclusion=$(echo "$gh_run_json" | jq -r '.conclusion // ""')
+
+	local gh_run_url
+	gh_run_url=$(echo "$gh_run_json" | jq -r '.url // ""')
+
+	local gh_run_event
+	gh_run_event=$(echo "$gh_run_json" | jq -r '.event // ""')
+
+	local gh_run_branch
+	gh_run_branch=$(echo "$gh_run_json" | jq -r '.headBranch // ""')
+
+	local gh_run_jq_file
+	gh_run_jq_file="$_gh_ai_source_dir/scripts/gh_run_explain.jq"
+
+	local gh_run_jobs
+	gh_run_jobs=$(echo "$gh_run_json" | jq -r -f "$gh_run_jq_file")
+
+	# Fetch logs: use --log-failed for failed runs, --log otherwise
+	local gh_run_log
+	if [[ "$gh_run_conclusion" == "failure" ]]; then
+		gh_run_log=$(gum spin --title "Fetching GitHub workflow run failed logs..." -- \
+			gh run view "$gh_run_id" --log-failed || true)
+	else
+		gh_run_log=$(gum spin --title "Fetching GitHub workflow run logs..." -- \
+			gh run view "$gh_run_id" --log || true)
+	fi
+
+	# Truncate to last 500 lines to keep prompt size reasonable
+	gh_run_log=$(echo "$gh_run_log" | tail -n 500)
+
+	local agent_model
+	agent_model=$(gh config get gh-ai.run.model 2>/dev/null || true)
+
+	local output
+	# Generate explanation using assistant run
+	output=$(
+		gum spin --title "Analyzing GitHub workflow run..." -- \
+			"$_gh_ai_source_dir/scripts/gh_cmd.sh" assist "$agent_model" < <(
+				GH_RUN_TITLE="$gh_run_title" GH_RUN_CONCLUSION="$gh_run_conclusion" GH_RUN_URL="$gh_run_url" GH_RUN_EVENT="$gh_run_event" GH_RUN_BRANCH="$gh_run_branch" GH_RUN_JOBS="$gh_run_jobs" GH_RUN_LOG="$gh_run_log" \
+					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
+			)
+	)
+
+	# Validate we got explanation content
+	if [[ -z "$output" ]]; then
+		gum log --level error "Failed to generate run explanation"
+		gum log --level info "Run with DEBUG=1 for detailed diagnostics"
+		return 1
+	fi
+
+	printf '%s\n' "$output"
+}
+
+# Run subcommand handler
+#
+# Routes run subcommands to their appropriate handler functions.
+# Shows help for unknown commands.
+#
+# Usage: _gh_run <subcommand> [OPTIONS]
+# Subcommands: explain, help
+_gh_run() {
+	local subcommand="${1:-}"
+	shift || true
+
+	case $subcommand in
+	explain)
+		_gh_run_explain "$@"
+		;;
+	--help | -h | help | "")
+		_show_run_help
+		;;
+	*)
+		gum log --level error "Unknown run command '$subcommand'"
+		gum log --level info "Available commands: explain"
+		gum log --level info "Run 'gh ai run --help' for usage information"
+		exit 1
+		;;
+	esac
+}

--- a/scripts/gh_run_explain.jq
+++ b/scripts/gh_run_explain.jq
@@ -1,0 +1,6 @@
+[.jobs[] | "- \(.name): \(.conclusion // .status)" +
+	(if .steps then
+		"\n" + ([.steps[] | select(.conclusion != "success" and .conclusion != "skipped") |
+			"    - Step \(.number) \(.name): \(.conclusion // .status)"] | join("\n"))
+	else "" end)
+] | join("\n")

--- a/templates/gh_run_explain.tmpl
+++ b/templates/gh_run_explain.tmpl
@@ -1,0 +1,41 @@
+Analyze this GitHub Actions workflow run and explain what happened.
+
+<run>
+Title: {{ param "GH_RUN_TITLE" }}
+Conclusion: {{ param "GH_RUN_CONCLUSION" }}
+Event: {{ param "GH_RUN_EVENT" }}
+Branch: {{ param "GH_RUN_BRANCH" }}
+URL: {{ param "GH_RUN_URL" }}
+</run>
+
+<jobs>
+{{ param "GH_RUN_JOBS" }}
+</jobs>
+
+<log>
+{{ param "GH_RUN_LOG" }}
+</log>
+
+<format>
+- Focus on root cause and actionable fixes
+- Highlight error messages and stack traces
+- Reference specific job/step names
+- Body: GitHub-flavored Markdown
+- Omit sections that do not apply; do not write "N/A"
+- Output only the explanation, no preamble or commentary
+- Do NOT include a title line
+</format>
+
+<body>
+## Summary
+{1–2 sentence overview of what happened}
+
+## Root Cause
+{clear explanation of why the run failed}
+
+## Failed Steps
+{list of failed jobs/steps with key error messages}
+
+## How to Fix
+{actionable steps to resolve the failure}
+</body>


### PR DESCRIPTION
## Summary

Introduces a new `run explain` subcommand that fetches metadata and logs for a GitHub Actions workflow run, then generates an AI-powered explanation of what happened. The command automatically uses `--log-failed` for failed runs and `--log` otherwise, truncating output to the last 500 lines to keep prompt size reasonable.

## Risk Level

- [x] Low (docs, tests, internal refactor)
- [ ] Medium (behavior change, non-critical path)
- [ ] High (core logic, data integrity, security, perf-critical)

## Changes

### Behavior & Execution Flow

`gh ai run explain <RUN_ID>` fetches run metadata via `gh run view --json`, extracts job/step summaries with a dedicated jq filter (`scripts/gh_run_explain.jq:1-6`), pulls logs (failed-only or full depending on conclusion), and pipes everything through the `gh_run_explain.tmpl` template into the AI assistant. The rendered explanation is printed to stdout with structured Markdown sections (Summary, Root Cause, Failed Steps, How to Fix).

The main entry point (`gh-ai:84-86`) routes the `run` subcommand to `_gh_run` in `scripts/gh_run.sh`, which in turn dispatches `explain` to `_gh_run_explain`.

### Design Decisions

- **Log strategy based on conclusion** (`scripts/gh_run.sh:104-111`): Failed runs fetch only `--log-failed` to reduce noise; non-failure runs fetch the full `--log`. This avoids dumping thousands of irrelevant lines for large workflows.
- **500-line tail truncation** (`scripts/gh_run.sh:114`): Hard cap keeps the AI prompt within token budgets while preserving the most relevant (latest) log output.
- **jq filter for job summaries** (`scripts/gh_run_explain.jq`): Extracts only non-success/non-skipped steps, giving the AI a compact structured view of what went wrong without parsing raw logs.
- **Dedicated model override** `gh-ai.run.model` follows the existing per-command config pattern used by `commit`, `pr`, and `issue`.

### Edge Cases

- **Missing run ID**: `_get_run_id` scans for the first numeric argument; if none is found, the command exits with an actionable error message (`scripts/gh_run.sh:69-72`).
- **Failed metadata fetch**: If `gh run view` fails (e.g., invalid ID, network error), the `|| true` prevents a hard crash and the empty-check on `gh_run_json` surfaces a user-friendly error (`scripts/gh_run.sh:78-81`).
- **Empty AI output**: Validated before printing, with a hint to re-run with `DEBUG=1` (`scripts/gh_run.sh:126-129`).

## Testing

```bash
# Explain a failed run
gh ai run explain <FAILED_RUN_ID>

# Explain a successful run
gh ai run explain <SUCCESS_RUN_ID>

# Missing run ID — should show usage error
gh ai run explain

# Help output
gh ai run --help
gh ai run explain --help

# With debug logging
DEBUG=1 gh ai run explain <RUN_ID>

# With model override
gh config set gh-ai.run.model sonnet && gh ai run explain <RUN_ID>
```

## Impact

- **Breaking Changes:** No — additive only; no existing commands or config keys are modified.
- **Performance:** No change to existing commands; new command makes 2 sequential `gh run view` API calls per invocation.
- **Security:** Logs are passed to the configured AI provider. Same trust boundary as existing `pr explain` and `issue create` commands.