### PR TITLE
Add `gh ai issue develop` command and improve CLI consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 # gh-ai
 
 A GitHub CLI extension that uses AI to generate commit messages, pull request
-descriptions, code reviews, PR explanations, and structured issues.
+descriptions, code reviews, PR explanations, structured issues, and
+implementation plans.
 
 ![License](https://img.shields.io/github/license/gh-extensions/gh-ai)
 ![Version](https://img.shields.io/github/v/release/gh-extensions/gh-ai)
 
 ## Prerequisites
 
+- [Bash](https://www.gnu.org/software/bash/) 4.4+ (`bash`) — macOS: `brew install bash`
 - [GitHub CLI](https://cli.github.com/) (`gh`)
 - [Claude Code](https://docs.anthropic.com/en/docs/build-with-claude/claude-code) (`claude`)
 - [gum](https://github.com/charmbracelet/gum)
@@ -28,6 +30,7 @@ gh ai pr create [GH_PR_CREATE_OPTIONS]
 gh ai pr review [PR_NUMBER] [GH_PR_REVIEW_OPTIONS]
 gh ai pr explain [PR_NUMBER] [--comment | --edit]
 gh ai issue create [-d DESCRIPTION] [GH_ISSUE_CREATE_OPTIONS]
+gh ai issue develop <ISSUE_NUMBER> [GH_ISSUE_DEVELOP_OPTIONS]
 gh ai run explain <RUN_ID>
 ```
 
@@ -77,6 +80,15 @@ gh ai issue create -d "Login crash" --label bug --assignee @me
 some_command 2>&1 | gh ai issue create -d "Command X fails" # pipe error context
 ```
 
+Develops an issue by creating a branch, generating an AI implementation plan,
+and opening a pull request.
+
+```bash
+gh ai issue develop 42
+gh ai issue develop 42 --draft
+gh ai issue develop 42 --base develop
+```
+
 ### Run
 
 Analyzes a GitHub Actions workflow run and explains what happened.
@@ -95,7 +107,7 @@ Override the AI provider and model via `gh config`.
 | `gh-ai.model`        | `haiku`     | Model for all commands (fallback)             |
 | `gh-ai.commit.model` |             | Model override for `commit`                   |
 | `gh-ai.pr.model`     |             | Model override for `pr create/review/explain` |
-| `gh-ai.issue.model`  |             | Model override for `issue create`             |
+| `gh-ai.issue.model`  |             | Model override for `issue create/develop`     |
 | `gh-ai.run.model`    |             | Model override for `run explain`              |
 
 Per-command keys take priority over `gh-ai.model`.

--- a/gh-ai
+++ b/gh-ai
@@ -8,9 +8,15 @@ _gh_ai_source_dir=$(dirname "${BASH_SOURCE[0]}")
 
 # Verify required dependencies are installed
 #
-# Checks that gh, claude, and gum are available on PATH.
+# Checks that Bash 4.4+, gh, claude, and gum are available.
 # Prints installation instructions and exits if any are missing.
 _check_dependencies() {
+	if [[ "${BASH_VERSINFO[0]}" -lt 4 || ("${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -lt 4) ]]; then
+		echo "gh-ai: requires Bash 4.4+ (found ${BASH_VERSION})" >&2
+		echo "  macOS: brew install bash" >&2
+		exit 1
+	fi
+
 	local missing=()
 
 	if ! command -v gh &>/dev/null; then
@@ -55,7 +61,7 @@ USAGE:
 COMMANDS:
     pr          Pull request operations (create, review, explain)
     commit      Generate a commit message for staged changes
-    issue       Issue operations (create)
+    issue       Issue operations (create, develop)
     run         Workflow run operations (explain)
 
 SEE ALSO:

--- a/scripts/gh_commit.sh
+++ b/scripts/gh_commit.sh
@@ -29,33 +29,38 @@ SEE ALSO:
 EOF
 }
 
-# Filter out flags managed by gh-ai from git commit arguments
+# Parse commit arguments in a single pass
 #
-# Removes -m/--message and -F/--file flags (and their values) since
-# the commit message is AI-generated. All other flags pass through.
-_filter_commit_args() {
-	local filtered=()
-	local skip_next=false
-	local arg
+# Strips AI-managed flags (-m/--message, -F/--file) and collects
+# passthrough args for git commit via nameref.
+#
+# Example: _parse_commit_args args --signoff -m "ignored"
+_parse_commit_args() {
+	local -n git_commit_args_ref="$1"
+	shift
 
-	for arg in "$@"; do
+	local args=("$@")
+	local skip_next=false
+	local i=0
+
+	while [[ $i -lt ${#args[@]} ]]; do
 		if [ "$skip_next" = true ]; then
 			skip_next=false
+			((++i))
 			continue
 		fi
 
-		case "$arg" in
+		case "${args[$i]}" in
 		-m | --message | -F | --file)
 			skip_next=true
 			;;
 		--message=* | --file=*) ;;
 		*)
-			filtered+=("$arg")
+			git_commit_args_ref+=("${args[$i]}")
 			;;
 		esac
+		((++i))
 	done
-
-	[[ ${#filtered[@]} -gt 0 ]] && printf '%s\n' "${filtered[@]}" || true
 }
 
 # Main commit command implementation
@@ -74,19 +79,13 @@ _gh_commit() {
 	esac
 
 	local args=("$@")
-	local clean_args
 
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_commit.tmpl"
 
-	local filtered_args
-	filtered_args=$(_filter_commit_args "${args[@]}")
-	if [[ -n "$filtered_args" ]]; then
-		IFS=$'\n' read -rd '' -a clean_args <<<"$filtered_args" || true
-	else
-		clean_args=()
-	fi
+	local git_commit_args=()
+	_parse_commit_args git_commit_args "${args[@]}"
 
 	# Gather git context
 	local git_diff_staged
@@ -129,5 +128,5 @@ _gh_commit() {
 	fi
 
 	# Commit with the generated message and pass through any extra args
-	git commit -m "$git_commit_message" "${clean_args[@]}"
+	git commit -m "$git_commit_message" "${git_commit_args[@]}"
 }

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -16,97 +16,303 @@ gh ai issue - Issue commands with AI assistance
 
 USAGE:
     gh ai issue create [-d DESCRIPTION] [GH_ISSUE_CREATE_OPTIONS]
+    gh ai issue develop <ISSUE_NUMBER> [GH_ISSUE_DEVELOP_OPTIONS]
 
 DESCRIPTION:
     Creates GitHub issues with AI-generated titles and structured bodies.
+    Develops issues by creating a branch, generating an implementation plan,
+    and opening a pull request.
 
 COMMANDS:
     create      Create issues with AI-generated content
+    develop     Create a branch and PR with an AI implementation plan
 
 SEE ALSO:
-    gh ai issue create --help    # Issue create usage
+    gh ai issue create --help     # Issue create usage
+    gh ai issue develop --help    # Issue develop usage
 EOF
 }
 
-# Extract issue description from arguments
+# Parse issue create arguments in a single pass
 #
-# Looks for -d/--description flag value.
+# Extracts the description, labels (comma-separated for the template),
+# and passthrough args for gh issue create via namerefs.
+# Labels pass through to gh issue create AND are collected for the template.
+# AI-managed flags (--title, --body, --body-file, --template) are stripped.
 #
-# Example: _get_issue_description -d "Login crash" --label bug  # Returns: Login crash
-_get_issue_description() {
-	local consume=false
+# Example: _parse_issue_create_args desc labels args -d "Login crash" --label bug
+_parse_issue_create_args() {
+	local -n gh_issue_description_ref="$1"
+	local -n gh_issue_labels_ref="$2"
+	local -n gh_issue_args_ref="$3"
+	shift 3
 
-	local arg
-	for arg in "$@"; do
-		if [ "$consume" = true ]; then
-			echo "$arg"
-			return 0
-		fi
-
-		case "$arg" in
-		--description | -d) consume=true ;;
-		--description=*)
-			echo "${arg#--description=}"
-			return 0
-			;;
-		esac
-	done
-}
-
-# Extract labels from arguments
-#
-# Collects values from -l/--label flags into a comma-separated string
-# for use in the prompt template context.
-#
-# Example: _get_issue_labels --label bug -l "high priority"  # Returns: bug, high priority
-_get_issue_labels() {
-	local issue_labels=""
-	local consume=false
-
-	local arg
-	for arg in "$@"; do
-		if [ "$consume" = true ]; then
-			issue_labels="${issue_labels:+$issue_labels, }$arg"
-			consume=false
-			continue
-		fi
-
-		case "$arg" in
-		--label | -l) consume=true ;;
-		--label=*) issue_labels="${issue_labels:+$issue_labels, }${arg#--label=}" ;;
-		esac
-	done
-
-	[[ -n "$issue_labels" ]] && echo "$issue_labels" || true
-}
-
-# Filter out flags managed by gh-ai from issue create arguments
-#
-# Removes description, title, body, and template flags (and their values)
-# since the issue content is AI-generated. All other flags pass through.
-_filter_issue_create_args() {
-	local filtered=()
+	local args=("$@")
 	local skip_next=false
-	local arg
+	local i=0
 
-	for arg in "$@"; do
+	while [[ $i -lt ${#args[@]} ]]; do
 		if [ "$skip_next" = true ]; then
 			skip_next=false
+			((++i))
 			continue
 		fi
 
-		case "$arg" in
-		--description | -d | --title | -t | --body | -b | --body-file | -F | --template | -T)
+		case "${args[$i]}" in
+		--description | -d)
+			gh_issue_description_ref="${args[$((i + 1))]}"
 			skip_next=true
 			;;
-		--description=* | --title=* | --body=* | --body-file=* | --template=*) ;;
+		--description=*)
+			gh_issue_description_ref="${args[$i]#--description=}"
+			;;
+		--label | -l)
+			gh_issue_labels_ref="${gh_issue_labels_ref:+$gh_issue_labels_ref, }${args[$((i + 1))]}"
+			gh_issue_args_ref+=("${args[$i]}" "${args[$((i + 1))]}")
+			skip_next=true
+			;;
+		--label=*)
+			gh_issue_labels_ref="${gh_issue_labels_ref:+$gh_issue_labels_ref, }${args[$i]#--label=}"
+			gh_issue_args_ref+=("${args[$i]}")
+			;;
+		--title | -t | --body | -b | --body-file | -F | --template | -T)
+			skip_next=true
+			;;
+		--title=* | --body=* | --body-file=* | --template=*) ;;
 		*)
-			filtered+=("$arg")
+			gh_issue_args_ref+=("${args[$i]}")
 			;;
 		esac
+		((++i))
 	done
+}
 
-	[[ ${#filtered[@]} -gt 0 ]] && printf '%s\n' "${filtered[@]}" || true
+# Parse issue develop arguments in a single pass
+#
+# Extracts the issue number (first numeric arg), gh issue develop flags
+# (--base, --name, --branch-repo), and gh pr create passthrough args
+# via namerefs. Develop-only flags are a small explicit set; everything
+# else passes through to gh pr create.
+#
+# Example: _parse_issue_develop_args num devargs prargs 42 --name my-branch --draft
+_parse_issue_develop_args() {
+	local -n gh_issue_number_ref="$1"
+	local -n gh_issue_args_ref="$2"
+	local -n gh_pr_args_ref="$3"
+	shift 3
+
+	local args=("$@")
+	local skip_next=false
+	local i=0
+
+	while [[ $i -lt ${#args[@]} ]]; do
+		if [ "$skip_next" = true ]; then
+			skip_next=false
+			((++i))
+			continue
+		fi
+
+		case "${args[$i]}" in
+		--base | -b | --name | -n | --branch-repo)
+			gh_issue_args_ref+=("${args[$i]}" "${args[$((i + 1))]}")
+			skip_next=true
+			;;
+		--base=* | --name=* | --branch-repo=*)
+			gh_issue_args_ref+=("${args[$i]}")
+			;;
+		--checkout | -c) ;;
+		--head | -H | -B)
+			skip_next=true
+			;;
+		--head=*) ;;
+		--title | -t | --body | --body-file | -F | --template | -T)
+			skip_next=true
+			;;
+		--title=* | --body=* | --body-file=* | --template=*) ;;
+		--fill | --fill-first | --fill-verbose) ;;
+		*)
+			if [[ -z "$gh_issue_number_ref" && "${args[$i]}" =~ ^[0-9]+$ ]]; then
+				gh_issue_number_ref="${args[$i]}"
+			else
+				gh_pr_args_ref+=("${args[$i]}")
+			fi
+			;;
+		esac
+		((++i))
+	done
+}
+
+# Issue develop help function
+#
+# Displays help information for the issue develop command
+# including usage examples and available options.
+_show_issue_develop_help() {
+	cat <<'EOF'
+gh ai issue develop - Create a branch and PR with an AI implementation plan
+
+USAGE:
+    gh ai issue develop <ISSUE_NUMBER> [OPTIONS]
+
+DESCRIPTION:
+    Creates a development branch from a GitHub issue, generates an AI
+    implementation plan, and opens a pull request with that plan.
+
+    Combines gh issue develop (branch creation) with gh pr create
+    (pull request). Title and body are AI-generated from the issue.
+
+BRANCH FLAGS (gh issue develop):
+    -b, --base string          Name of the remote branch to branch from
+    -n, --name string          Name of the branch to create
+        --branch-repo string   Name or URL of the repo for the new branch
+
+PR FLAGS (gh pr create):
+    -a, --assignee login       Assign people by their login
+    -d, --draft                Mark pull request as a draft
+        --dry-run              Print details instead of creating the PR
+    -e, --editor               Open text editor for title and body
+    -l, --label name           Add labels by name
+    -m, --milestone name       Add the pull request to a milestone
+        --no-maintainer-edit   Disable maintainer's ability to modify PR
+    -p, --project title        Add the pull request to projects
+    -r, --reviewer handle      Request reviews from people or teams
+    -w, --web                  Open the web browser to create the PR
+
+EXAMPLES:
+    gh ai issue develop 42
+    gh ai issue develop 42 --draft
+    gh ai issue develop 42 --base develop --label enhancement
+    gh ai issue develop 42 --reviewer monalisa --milestone v1.0
+EOF
+}
+
+# Issue Develop implementation
+#
+# Creates a development branch from an issue, generates an AI implementation
+# plan, and opens a pull request with that plan as the body.
+# Uses native `gh issue develop` for branch creation.
+#
+# Usage: _gh_issue_develop <ISSUE_NUMBER> [OPTIONS]
+_gh_issue_develop() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_issue_develop_help
+		return 0
+		;;
+	esac
+
+	local args=("$@")
+
+	local template_file
+	# shellcheck disable=SC2154
+	template_file="$_gh_ai_source_dir/templates/gh_issue_develop.tmpl"
+
+	local gh_issue_number=""
+	local gh_issue_args=()
+	local gh_pr_args=()
+	_parse_issue_develop_args gh_issue_number gh_issue_args gh_pr_args "${args[@]}"
+
+	if [[ -z "$gh_issue_number" ]]; then
+		gum log --level error "No issue number provided"
+		gum log --level info "Usage: gh ai issue develop <ISSUE_NUMBER> [OPTIONS]"
+		return 1
+	fi
+
+	# Fetch issue metadata
+	local gh_issue_meta
+	gh_issue_meta=$(gum spin --title "Fetching GitHub issue metadata..." -- \
+		gh issue view "$gh_issue_number" --json title,body,labels,comments || true)
+	if [[ -z "$gh_issue_meta" ]]; then
+		gum log --level error "Failed to fetch issue #$gh_issue_number"
+		return 1
+	fi
+
+	local gh_issue_title
+	gh_issue_title=$(echo "$gh_issue_meta" | jq -r '.title // ""')
+
+	local gh_issue_body
+	gh_issue_body=$(echo "$gh_issue_meta" | jq -r '.body // ""')
+
+	local gh_issue_labels
+	gh_issue_labels=$(echo "$gh_issue_meta" | jq -r '[.labels[].name] | join(", ")')
+
+	local gh_issue_comments
+	gh_issue_comments=$(echo "$gh_issue_meta" | jq -r '[.comments[].body] | join("\n---\n")')
+
+	local agent_model
+	agent_model=$(gh config get gh-ai.issue.model 2>/dev/null || true)
+
+	local output
+	# Generate implementation plan using assistant
+	output=$(
+		gum spin --title "Generating GitHub issue implementation plan..." -- \
+			"$_gh_ai_source_dir/scripts/gh_cmd.sh" assist "$agent_model" < <(
+				GH_ISSUE_NUMBER="$gh_issue_number" GH_ISSUE_TITLE="$gh_issue_title" GH_ISSUE_BODY="$gh_issue_body" GH_ISSUE_LABELS="$gh_issue_labels" GH_ISSUE_COMMENTS="$gh_issue_comments" \
+					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
+			)
+	)
+
+	# Validate we got content
+	if [[ -z "$output" ]]; then
+		gum log --level error "Failed to generate implementation plan"
+		gum log --level info "Run with DEBUG=1 for detailed diagnostics"
+		return 1
+	fi
+
+	local gh_pr_title
+	# Parse title from output
+	if ! gh_pr_title=$(_get_title "$output"); then
+		gum log --level error "Failed to extract title from AI content"
+		return 1
+	fi
+
+	local gh_pr_body
+	# Parse body from output
+	gh_pr_body=$(_get_body "$output")
+
+	# Validate we got body content
+	if [[ -z "$gh_pr_body" ]]; then
+		gum log --level error "Failed to extract body from AI content"
+		return 1
+	fi
+
+	# Create the development branch and checkout
+	gh issue develop "$gh_issue_number" --checkout "${gh_issue_args[@]}"
+
+	# Empty commit so the PR has a diff against the base branch
+	git commit --allow-empty -m "chore: start work on #$gh_issue_number"
+	git push -u origin HEAD
+
+	# Create the pull request
+	gh pr create --title "$gh_pr_title" --body "$gh_pr_body" "${gh_pr_args[@]}"
+}
+
+# Issue create help function
+#
+# Displays help information for the issue create command
+# including usage examples and available options.
+_show_issue_create_help() {
+	cat <<'EOF'
+gh ai issue create - Create issues with AI-generated content
+
+USAGE:
+    gh ai issue create -d <DESCRIPTION> [OPTIONS]
+
+DESCRIPTION:
+    Creates a GitHub issue with an AI-generated title and structured body
+    from a brief description. Supports piped stdin as additional context.
+
+FLAGS:
+    -d, --description string   Brief description of the issue (required)
+
+PASSTHROUGH FLAGS:
+    All other flags are passed directly to gh issue create.
+    See gh issue create --help for the full list.
+
+EXAMPLES:
+    gh ai issue create -d "Login page crashes with special chars"
+    gh ai issue create -d "Login crash" --label bug --assignee @me
+    some_command 2>&1 | gh ai issue create -d "Command X fails"
+EOF
 }
 
 # Issue Create implementation
@@ -118,26 +324,23 @@ _filter_issue_create_args() {
 #
 # Usage: _gh_issue_create [-d DESCRIPTION] [GH_ISSUE_CREATE_OPTIONS]
 _gh_issue_create() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_issue_create_help
+		return 0
+		;;
+	esac
+
 	local args=("$@")
-	local clean_args
 
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_issue_create.tmpl"
 
-	local filtered_args
-	filtered_args=$(_filter_issue_create_args "${args[@]}")
-	if [[ -n "$filtered_args" ]]; then
-		IFS=$'\n' read -rd '' -a clean_args <<<"$filtered_args" || true
-	else
-		clean_args=()
-	fi
-
-	local gh_issue_description
-	gh_issue_description=$(_get_issue_description "${args[@]}")
-
-	local gh_issue_labels
-	gh_issue_labels=$(_get_issue_labels "${args[@]}")
+	local gh_issue_description=""
+	local gh_issue_labels=""
+	local gh_issue_args=()
+	_parse_issue_create_args gh_issue_description gh_issue_labels gh_issue_args "${args[@]}"
 
 	# If no description, error out
 	if [[ -z "$gh_issue_description" ]]; then
@@ -190,7 +393,7 @@ _gh_issue_create() {
 	fi
 
 	# Create issue with AI-generated content
-	gh issue create --title "$gh_issue_title" --body "$gh_issue_body" "${clean_args[@]}"
+	gh issue create --title "$gh_issue_title" --body "$gh_issue_body" "${gh_issue_args[@]}"
 }
 
 # Issue subcommand handler
@@ -199,7 +402,7 @@ _gh_issue_create() {
 # Shows help for unknown commands.
 #
 # Usage: _gh_issue <subcommand> [OPTIONS]
-# Subcommands: create, help
+# Subcommands: create, develop, help
 _gh_issue() {
 	local subcommand="${1:-}"
 	shift || true
@@ -208,12 +411,15 @@ _gh_issue() {
 	create)
 		_gh_issue_create "$@"
 		;;
+	develop)
+		_gh_issue_develop "$@"
+		;;
 	--help | -h | help | "")
 		_show_issue_help
 		;;
 	*)
 		gum log --level error "Unknown issue command '$subcommand'"
-		gum log --level info "Available commands: create"
+		gum log --level info "Available commands: create, develop"
 		gum log --level info "Run 'gh ai issue --help' for usage information"
 		exit 1
 		;;

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -6,63 +6,76 @@ set -euo pipefail
 
 # PR-related functions for gh-ai
 
-# Resolve PR number from arguments or current branch
+# Parse PR create arguments in a single pass
 #
-# First looks for a numeric argument in the provided args.
-# Falls back to auto-detecting the PR for the current branch via gh pr view.
-# Returns the PR number or empty string if none found.
+# Extracts the --base branch value and passthrough args for gh pr create
+# via namerefs. --base passes through AND is captured for git diff.
+# AI-managed flags (--title, --body, --body-file, --template, --fill*) are stripped.
 #
-# Example: _get_pr_number review 123 --body "test"  # Returns: 123
-# Example: _get_pr_number --approve                 # Returns: detected PR number
-_get_pr_number() {
+# Example: _parse_pr_create_args base args --base develop --draft
+_parse_pr_create_args() {
+	local -n git_base_branch_ref="$1"
+	local -n gh_pr_args_ref="$2"
+	shift 2
+
 	local args=("$@")
+	local skip_next=false
 	local i=0
 
-	# Look for a numeric argument (PR number)
 	while [[ $i -lt ${#args[@]} ]]; do
-		if [[ "${args[$i]}" =~ ^[0-9]+$ ]]; then
-			echo "${args[$i]}"
-			return 0
-		fi
-		((++i))
-	done
-
-	local pr_number
-	pr_number=$(gh pr view --json number -q '.number' 2>/dev/null || true)
-	# Fall back to auto-detecting PR for current branch
-	if [[ -n "$pr_number" ]]; then
-		echo "$pr_number"
-	fi
-}
-
-# Filter out flags managed by gh-ai from pr create arguments
-#
-# Removes title, body, template, and fill flags (and their values) since
-# the PR content is AI-generated. All other flags pass through.
-_filter_pr_create_args() {
-	local filtered=()
-	local skip_next=false
-	local arg
-
-	for arg in "$@"; do
 		if [ "$skip_next" = true ]; then
 			skip_next=false
+			((++i))
 			continue
 		fi
 
-		case "$arg" in
+		case "${args[$i]}" in
+		--base | -B)
+			git_base_branch_ref="${args[$((i + 1))]}"
+			gh_pr_args_ref+=("${args[$i]}" "${args[$((i + 1))]}")
+			skip_next=true
+			;;
+		--base=*)
+			git_base_branch_ref="${args[$i]#--base=}"
+			gh_pr_args_ref+=("${args[$i]}")
+			;;
 		--title | -t | --body | -b | --body-file | -F | --template | -T)
 			skip_next=true
 			;;
 		--title=* | --body=* | --body-file=* | --template=*) ;;
 		--fill | --fill-first | --fill-verbose) ;;
 		*)
-			filtered+=("$arg")
+			gh_pr_args_ref+=("${args[$i]}")
 			;;
 		esac
+		((++i))
 	done
+}
 
-	[[ ${#filtered[@]} -gt 0 ]] && printf '%s\n' "${filtered[@]}" || true
+# PR create help function
+#
+# Displays help information for the PR create command
+# including usage examples and available options.
+_show_pr_create_help() {
+	cat <<'EOF'
+gh ai pr create - Create PRs with AI-generated titles and descriptions
+
+USAGE:
+    gh ai pr create [OPTIONS]
+
+DESCRIPTION:
+    Creates a GitHub pull request with an AI-generated title and description
+    based on the diff and commit history between the current and base branch.
+
+PASSTHROUGH FLAGS:
+    All flags are passed directly to gh pr create.
+    See gh pr create --help for the full list.
+
+EXAMPLES:
+    gh ai pr create
+    gh ai pr create --draft
+    gh ai pr create --draft --base develop
+EOF
 }
 
 # PR Create implementation
@@ -73,37 +86,31 @@ _filter_pr_create_args() {
 #
 # Usage: _gh_pr_create [GH_PR_CREATE_OPTIONS]
 _gh_pr_create() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_pr_create_help
+		return 0
+		;;
+	esac
+
 	local args=("$@")
-	local clean_args
 
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_pr_create.tmpl"
 
-	local filtered_args
-	filtered_args=$(_filter_pr_create_args "${args[@]}")
-	if [[ -n "$filtered_args" ]]; then
-		IFS=$'\n' read -rd '' -a clean_args <<<"$filtered_args" || true
-	else
-		clean_args=()
-	fi
+	local git_base_branch=""
+	local gh_pr_args=()
+	_parse_pr_create_args git_base_branch gh_pr_args "${args[@]}"
 
 	local git_head_branch
 	git_head_branch=$(git rev-parse --abbrev-ref HEAD)
 
-	local git_base_branch
-	git_base_branch=$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||' ||
-		gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")
-
-	# Check for --base flag in args to override default
-	local i=0
-	while [[ $i -lt ${#args[@]} ]]; do
-		if [[ "${args[$i]}" == "--base" ]] && [[ $((i + 1)) -lt ${#args[@]} ]]; then
-			git_base_branch="${args[$((i + 1))]}"
-			break
-		fi
-		((++i))
-	done
+	# Fall back to default base branch if --base not provided
+	if [[ -z "$git_base_branch" ]]; then
+		git_base_branch=$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||' ||
+			gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")
+	fi
 
 	# Get diff between base and head
 	local git_diff
@@ -170,40 +177,116 @@ _gh_pr_create() {
 	fi
 
 	# Create PR with AI-generated content
-	gh pr create --title "$gh_pr_title" --body "$gh_pr_body" "${clean_args[@]}"
+	gh pr create --title "$gh_pr_title" --body "$gh_pr_body" "${gh_pr_args[@]}"
 }
 
-# Filter out flags managed by gh-ai from pr review arguments
+# Parse PR explain arguments in a single pass
 #
-# Removes body flags (and their values) and the PR number since
-# the review content is AI-generated. All other flags pass through.
-_filter_pr_review_args() {
-	local pr_number="$1"
-	shift
+# Extracts the PR number (first numeric arg, with auto-detect fallback),
+# output mode (--comment or --edit), and passthrough args via namerefs.
+#
+# Example: _parse_pr_explain_args num mode 42 --comment
+_parse_pr_explain_args() {
+	local -n gh_pr_number_ref="$1"
+	local -n gh_pr_output_mode_ref="$2"
+	shift 2
 
-	local filtered=()
+	local args=("$@")
+	local i=0
+
+	while [[ $i -lt ${#args[@]} ]]; do
+		case "${args[$i]}" in
+		--comment)
+			gh_pr_output_mode_ref="comment"
+			;;
+		--edit)
+			gh_pr_output_mode_ref="edit"
+			;;
+		*)
+			if [[ -z "$gh_pr_number_ref" && "${args[$i]}" =~ ^[0-9]+$ ]]; then
+				gh_pr_number_ref="${args[$i]}"
+			fi
+			;;
+		esac
+		((++i))
+	done
+
+	# Auto-detect PR number from current branch if not found in args
+	if [[ -z "$gh_pr_number_ref" ]]; then
+		gh_pr_number_ref=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+	fi
+}
+
+# Parse PR review arguments in a single pass
+#
+# Extracts the PR number (first numeric arg, with auto-detect fallback)
+# and passthrough args for gh pr review via namerefs.
+# AI-managed flags (--body, --body-file) and the PR number are stripped.
+#
+# Example: _parse_pr_review_args num args 42 --approve
+_parse_pr_review_args() {
+	local -n gh_pr_number_ref="$1"
+	local -n gh_pr_args_ref="$2"
+	shift 2
+
+	local args=("$@")
 	local skip_next=false
-	local arg
+	local i=0
 
-	for arg in "$@"; do
+	while [[ $i -lt ${#args[@]} ]]; do
 		if [ "$skip_next" = true ]; then
 			skip_next=false
+			((++i))
 			continue
 		fi
 
-		case "$arg" in
+		case "${args[$i]}" in
 		--body | -b | --body-file | -F)
 			skip_next=true
 			;;
 		--body=* | --body-file=*) ;;
-		"$pr_number") ;;
 		*)
-			filtered+=("$arg")
+			if [[ -z "$gh_pr_number_ref" && "${args[$i]}" =~ ^[0-9]+$ ]]; then
+				gh_pr_number_ref="${args[$i]}"
+			else
+				gh_pr_args_ref+=("${args[$i]}")
+			fi
 			;;
 		esac
+		((++i))
 	done
 
-	[[ ${#filtered[@]} -gt 0 ]] && printf '%s\n' "${filtered[@]}" || true
+	# Auto-detect PR number from current branch if not found in args
+	if [[ -z "$gh_pr_number_ref" ]]; then
+		gh_pr_number_ref=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+	fi
+}
+
+# PR review help function
+#
+# Displays help information for the PR review command
+# including usage examples and available options.
+_show_pr_review_help() {
+	cat <<'EOF'
+gh ai pr review - Review PRs with AI-generated feedback
+
+USAGE:
+    gh ai pr review [PR_NUMBER] [OPTIONS]
+
+DESCRIPTION:
+    Submits a GitHub PR review with AI-generated feedback based on the
+    diff and commit history. Auto-detects PR from the current branch
+    if no number is provided.
+
+PASSTHROUGH FLAGS:
+    All flags are passed directly to gh pr review.
+    See gh pr review --help for the full list.
+
+EXAMPLES:
+    gh ai pr review 42
+    gh ai pr review 42 --approve
+    gh ai pr review              # auto-detect PR from current branch
+EOF
 }
 
 # PR Review implementation
@@ -215,28 +298,27 @@ _filter_pr_review_args() {
 #
 # Usage: _gh_pr_review [PR_NUMBER] [GH_PR_REVIEW_OPTIONS]
 _gh_pr_review() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_pr_review_help
+		return 0
+		;;
+	esac
+
 	local args=("$@")
-	local clean_args
 
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_pr_review.tmpl"
 
-	local gh_pr_number
-	# Resolve PR number from arguments or auto-detect from current branch
-	gh_pr_number=$(_get_pr_number "${args[@]}")
+	local gh_pr_number=""
+	local gh_pr_args=()
+	_parse_pr_review_args gh_pr_number gh_pr_args "${args[@]}"
+
 	if [[ -z "$gh_pr_number" ]]; then
 		gum log --level error "No PR number provided and could not detect PR for current branch"
 		gum log --level info "Usage: gh ai pr review <PR_NUMBER> [OPTIONS]"
 		return 1
-	fi
-
-	local filtered_args
-	filtered_args=$(_filter_pr_review_args "$gh_pr_number" "${args[@]}")
-	if [[ -n "$filtered_args" ]]; then
-		IFS=$'\n' read -rd '' -a clean_args <<<"$filtered_args" || true
-	else
-		clean_args=()
 	fi
 
 	# Get PR diff using gh cli (--patch for full patch format)
@@ -280,7 +362,35 @@ _gh_pr_review() {
 	fi
 
 	# Submit review with AI-generated content
-	gh pr review "$gh_pr_number" --body "$gh_pr_body" "${clean_args[@]}"
+	gh pr review "$gh_pr_number" --body "$gh_pr_body" "${gh_pr_args[@]}"
+}
+
+# PR explain help function
+#
+# Displays help information for the PR explain command
+# including usage examples and available options.
+_show_pr_explain_help() {
+	cat <<'EOF'
+gh ai pr explain - Generate a plain-language explanation of a PR
+
+USAGE:
+    gh ai pr explain [PR_NUMBER] [--comment | --edit]
+
+DESCRIPTION:
+    Generates a plain-language explanation of what a pull request does.
+    By default prints to stdout. Auto-detects PR from the current branch
+    if no number is provided.
+
+FLAGS:
+        --comment   Post the explanation as a PR comment
+        --edit      Replace the PR description with the explanation
+
+EXAMPLES:
+    gh ai pr explain 42              # print to stdout
+    gh ai pr explain                 # auto-detect PR from current branch
+    gh ai pr explain 42 --comment    # post as PR comment
+    gh ai pr explain 42 --edit       # replace PR description
+EOF
 }
 
 # PR Explain implementation
@@ -290,15 +400,23 @@ _gh_pr_review() {
 #
 # Usage: _gh_pr_explain [PR_NUMBER] [--comment | --edit]
 _gh_pr_explain() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_pr_explain_help
+		return 0
+		;;
+	esac
+
 	local args=("$@")
 
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_pr_explain.tmpl"
 
-	local gh_pr_number
-	# Resolve PR number from arguments or auto-detect from current branch
-	gh_pr_number=$(_get_pr_number "${args[@]}")
+	local gh_pr_number=""
+	local gh_pr_output_mode=""
+	_parse_pr_explain_args gh_pr_number gh_pr_output_mode "${args[@]}"
+
 	if [[ -z "$gh_pr_number" ]]; then
 		gum log --level error "No PR number provided and could not detect PR for current branch"
 		gum log --level info "Usage: gh ai pr explain [PR_NUMBER] [--comment | --edit]"
@@ -353,22 +471,18 @@ _gh_pr_explain() {
 		return 1
 	fi
 
-	# Output based on flags
-	local arg
-	for arg in "${args[@]}"; do
-		case "$arg" in
-		--comment)
-			gh pr comment "$gh_pr_number" --body "$output"
-			return 0
-			;;
-		--edit)
-			gh pr edit "$gh_pr_number" --body "$output"
-			return 0
-			;;
-		esac
-	done
-
-	printf '%s\n' "$output"
+	# Output based on mode
+	case "$gh_pr_output_mode" in
+	comment)
+		gh pr comment "$gh_pr_number" --body "$output"
+		;;
+	edit)
+		gh pr edit "$gh_pr_number" --body "$output"
+		;;
+	*)
+		printf '%s\n' "$output"
+		;;
+	esac
 }
 
 # PR help function

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -6,19 +6,21 @@ set -euo pipefail
 
 # Run-related functions for gh-ai
 
-# Extract run ID from arguments
+# Parse run explain arguments in a single pass
 #
-# Looks for the first numeric argument in the provided args.
-# Returns the run ID or empty string if none found.
+# Extracts the run ID (first numeric arg) via nameref.
 #
-# Example: _get_run_id explain 123456  # Returns: 123456
-_get_run_id() {
+# Example: _parse_run_explain_args id 123456
+_parse_run_explain_args() {
+	local -n gh_run_id_ref="$1"
+	shift
+
 	local args=("$@")
 	local i=0
 
 	while [[ $i -lt ${#args[@]} ]]; do
-		if [[ "${args[$i]}" =~ ^[0-9]+$ ]]; then
-			echo "${args[$i]}"
+		if [[ -z "$gh_run_id_ref" && "${args[$i]}" =~ ^[0-9]+$ ]]; then
+			gh_run_id_ref="${args[$i]}"
 			return 0
 		fi
 		((++i))
@@ -47,6 +49,27 @@ SEE ALSO:
 EOF
 }
 
+# Run explain help function
+#
+# Displays help information for the run explain command
+# including usage examples and available options.
+_show_run_explain_help() {
+	cat <<'EOF'
+gh ai run explain - Analyze a workflow run and explain failures
+
+USAGE:
+    gh ai run explain <RUN_ID>
+
+DESCRIPTION:
+    Analyzes a GitHub Actions workflow run and generates an AI explanation
+    of what happened, focusing on root cause and actionable fixes.
+    Uses --log-failed for failed runs and --log otherwise.
+
+EXAMPLES:
+    gh ai run explain 123456
+EOF
+}
+
 # Run Explain implementation
 #
 # Analyzes a GitHub Actions workflow run and generates an AI explanation
@@ -55,14 +78,21 @@ EOF
 #
 # Usage: _gh_run_explain <RUN_ID>
 _gh_run_explain() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_run_explain_help
+		return 0
+		;;
+	esac
+
 	local args=("$@")
 
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_run_explain.tmpl"
 
-	local gh_run_id
-	gh_run_id=$(_get_run_id "${args[@]}")
+	local gh_run_id=""
+	_parse_run_explain_args gh_run_id "${args[@]}"
 	if [[ -z "$gh_run_id" ]]; then
 		gum log --level error "No run ID provided"
 		gum log --level info "Usage: gh ai run explain <RUN_ID>"
@@ -70,34 +100,34 @@ _gh_run_explain() {
 	fi
 
 	# Fetch run metadata
-	local gh_run_json
-	gh_run_json=$(gum spin --title "Fetching GitHub workflow run metadata..." -- \
+	local gh_run_meta
+	gh_run_meta=$(gum spin --title "Fetching GitHub workflow run metadata..." -- \
 		gh run view "$gh_run_id" --json displayTitle,conclusion,url,event,headBranch,jobs || true)
-	if [[ -z "$gh_run_json" ]]; then
+	if [[ -z "$gh_run_meta" ]]; then
 		gum log --level error "Failed to fetch run $gh_run_id"
 		return 1
 	fi
 
 	local gh_run_title
-	gh_run_title=$(echo "$gh_run_json" | jq -r '.displayTitle // ""')
+	gh_run_title=$(echo "$gh_run_meta" | jq -r '.displayTitle // ""')
 
 	local gh_run_conclusion
-	gh_run_conclusion=$(echo "$gh_run_json" | jq -r '.conclusion // ""')
+	gh_run_conclusion=$(echo "$gh_run_meta" | jq -r '.conclusion // ""')
 
 	local gh_run_url
-	gh_run_url=$(echo "$gh_run_json" | jq -r '.url // ""')
+	gh_run_url=$(echo "$gh_run_meta" | jq -r '.url // ""')
 
 	local gh_run_event
-	gh_run_event=$(echo "$gh_run_json" | jq -r '.event // ""')
+	gh_run_event=$(echo "$gh_run_meta" | jq -r '.event // ""')
 
 	local gh_run_branch
-	gh_run_branch=$(echo "$gh_run_json" | jq -r '.headBranch // ""')
+	gh_run_branch=$(echo "$gh_run_meta" | jq -r '.headBranch // ""')
 
 	local gh_run_jq_file
 	gh_run_jq_file="$_gh_ai_source_dir/scripts/gh_run_explain.jq"
 
 	local gh_run_jobs
-	gh_run_jobs=$(echo "$gh_run_json" | jq -r -f "$gh_run_jq_file")
+	gh_run_jobs=$(echo "$gh_run_meta" | jq -r -f "$gh_run_jq_file")
 
 	# Fetch logs: use --log-failed for failed runs, --log otherwise
 	local gh_run_log

--- a/templates/gh_issue_develop.tmpl
+++ b/templates/gh_issue_develop.tmpl
@@ -1,0 +1,43 @@
+Create an implementation plan for the following GitHub issue.
+
+<issue>
+Number: {{ param "GH_ISSUE_NUMBER" }}
+Title: {{ param "GH_ISSUE_TITLE" }}
+Body: {{ param "GH_ISSUE_BODY" }}
+Labels: {{ param "GH_ISSUE_LABELS" }}
+</issue>
+
+<comments>
+{{ param "GH_ISSUE_COMMENTS" }}
+</comments>
+
+<format>
+- First line: PR title — `# {title}`, clear and specific, under 72 chars
+- Body: GitHub-flavored Markdown
+- Include `Closes #N` reference to the issue
+- Implementation plan as a TODO checklist with concrete steps, each prefixed with a sequential ID: `T001 - {step}`
+- Acceptance criteria as checkboxes
+- Omit sections that do not apply; do not write "N/A"
+- Output only the PR content, no preamble or commentary
+</format>
+
+<body>
+# {title}
+
+Closes #{{ param "GH_ISSUE_NUMBER" }}
+
+## Summary
+
+{1–2 sentence overview of what this PR will implement}
+
+## Implementation Plan
+
+- [ ] T001 - {concrete implementation step}
+- [ ] T002 - {concrete implementation step}
+- [ ] T003 - {concrete implementation step}
+
+## Acceptance Criteria
+
+- [ ] {criterion that defines "done"}
+- [ ] {criterion that defines "done"}
+</body>


### PR DESCRIPTION
## Summary

Introduces `gh ai issue develop`, which creates a branch from a GitHub issue, generates an AI implementation plan, and opens a pull request with that plan as the body. Alongside this, all argument parsing across commands is refactored from multi-pass filter/extract functions to single-pass nameref-based parsers, and every subcommand gains a dedicated `--help` handler.

## Risk Level

- [ ] Low (docs, tests, internal refactor)
- [x] Medium (behavior change, non-critical path)
- [ ] High (core logic, data integrity, security, perf-critical)

## Changes

### Behavior & Execution Flow

`gh ai issue develop <ISSUE_NUMBER>` fetches issue metadata (title, body, labels, comments), renders a new `gh_issue_develop.tmpl` prompt, sends it to the AI assistant, extracts a PR title and Markdown body containing an implementation plan with a TODO checklist, then runs `gh issue develop --checkout` to create/switch to the branch, pushes an empty commit, and opens a PR via `gh pr create`.

All subcommands (`commit`, `pr create`, `pr review`, `pr explain`, `issue create`, `run explain`) now handle `--help | -h | help` as the first argument and short-circuit to a dedicated help function. The top-level `gh ai issue` router advertises `develop` alongside `create`.

A Bash 4.4+ version check is enforced in `_check_dependencies` (`gh-ai:11-14`) since namerefs (`local -n`) require it.

### Design Decisions

- **Single-pass nameref parsers** (`_parse_commit_args`, `_parse_issue_create_args`, `_parse_issue_develop_args`, `_parse_pr_create_args`, `_parse_pr_review_args`, `_parse_run_explain_args`) replace the previous pattern of separate `_get_*` extractors + `_filter_*_args` functions that serialized arrays through `printf`/`IFS` round-trips. This eliminates a class of bugs around arguments containing whitespace or newlines.
- **`--base` in `_parse_pr_create_args`** is both captured for the git diff range and passed through to `gh pr create`, avoiding the old second loop over args in `_gh_pr_create`.
- **`gh issue develop` flags** (`--base`, `--name`, `--branch-repo`) are separated from PR-create passthrough flags (`--draft`, `--label`, `--assignee`, etc.) in `_parse_issue_develop_args` (`gh_issue.sh:109-155`). AI-managed flags (`--title`, `--body`, `--fill*`) are silently stripped.
- The template (`gh_issue_develop.tmpl`) asks for a `# {title}` first line followed by a `Closes #N` reference, implementation TODO checklist with sequential IDs, and acceptance criteria — matching the existing title/body extraction helpers (`_get_title`, `_get_body`).

### Edge Cases

- If no issue number is provided, `_gh_issue_develop` exits early with an error and usage hint.
- If `gh issue view` fails (private repo, bad number), the empty-check on `gh_issue_meta` catches it before AI generation.
- `_parse_pr_review_args` and `_parse_issue_develop_args` accept the PR/issue number as the first bare numeric argument; non-numeric bare arguments fall through to passthrough.
- `_parse_pr_create_args` falls back to `origin/HEAD` or `defaultBranchRef` only when `--base` is absent, preserving the previous default-branch detection.
- `--checkout` and `-c` flags in `_parse_issue_develop_args` are silently consumed since the command always checks out.

## Testing

```bash
# Verify Bash version gate
bash --version  # must be 4.4+

# Help output for new and existing commands
gh ai issue develop --help
gh ai issue create --help
gh ai pr create --help
gh ai pr review --help
gh ai pr explain --help
gh ai run explain --help

# End-to-end issue develop (requires a real issue)
gh ai issue develop <ISSUE_NUMBER> --draft

# Verify existing commands still work
gh ai commit --signoff
gh ai pr create --draft --base main
gh ai pr review <PR_NUMBER>
gh ai issue create -d "Test issue" --label test
```

## Impact

- **Breaking Changes:** Requires Bash 4.4+ (previously no explicit minimum). macOS ships 3.2; users must `brew install bash`.
- **Performance:** No change — network calls dominate; parsing is negligible.
- **Security:** No new trust boundaries; AI input/output handling unchanged.