### PR TITLE
Add `gh ai issue edit` command for AI-assisted issue updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # gh-ai
 
 A GitHub CLI extension that uses AI to generate commit messages, pull request
-descriptions, code reviews, PR explanations, structured issues, and
-implementation plans.
+descriptions, code reviews, PR explanations, structured issues, issue edits,
+and implementation plans.
 
 ![License](https://img.shields.io/github/license/gh-extensions/gh-ai)
 ![Version](https://img.shields.io/github/v/release/gh-extensions/gh-ai)
@@ -30,6 +30,7 @@ gh ai pr create [GH_PR_CREATE_OPTIONS]
 gh ai pr review [PR_NUMBER] [GH_PR_REVIEW_OPTIONS]
 gh ai pr explain [PR_NUMBER] [--comment | --edit]
 gh ai issue create [-d DESCRIPTION] [GH_ISSUE_CREATE_OPTIONS]
+gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [GH_ISSUE_EDIT_OPTIONS]
 gh ai issue develop <ISSUE_NUMBER> [GH_ISSUE_DEVELOP_OPTIONS]
 gh ai run explain <RUN_ID>
 ```
@@ -80,6 +81,15 @@ gh ai issue create -d "Login crash" --label bug --assignee @me
 some_command 2>&1 | gh ai issue create -d "Command X fails" # pipe error context
 ```
 
+Edits an existing issue with AI-generated updates based on a description of
+what to change.
+
+```bash
+gh ai issue edit 42 -d "add acceptance criteria"
+gh ai issue edit 42 -d "fix typos and improve clarity"
+gh ai issue edit 42 -d "rephrase as a bug report" --add-label bug
+```
+
 Develops an issue by creating a branch, generating an AI implementation plan,
 and opening a pull request.
 
@@ -107,7 +117,7 @@ Override the AI provider and model via `gh config`.
 | `gh-ai.model`        | `haiku`     | Model for all commands (fallback)             |
 | `gh-ai.commit.model` |             | Model override for `commit`                   |
 | `gh-ai.pr.model`     |             | Model override for `pr create/review/explain` |
-| `gh-ai.issue.model`  |             | Model override for `issue create/develop`     |
+| `gh-ai.issue.model`  |             | Model override for `issue create/edit/develop` |
 | `gh-ai.run.model`    |             | Model override for `run explain`              |
 
 Per-command keys take priority over `gh-ai.model`.

--- a/gh-ai
+++ b/gh-ai
@@ -61,7 +61,7 @@ USAGE:
 COMMANDS:
     pr          Pull request operations (create, review, explain)
     commit      Generate a commit message for staged changes
-    issue       Issue operations (create, develop)
+    issue       Issue operations (create, edit, develop)
     run         Workflow run operations (explain)
 
 SEE ALSO:

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -16,19 +16,22 @@ gh ai issue - Issue commands with AI assistance
 
 USAGE:
     gh ai issue create [-d DESCRIPTION] [GH_ISSUE_CREATE_OPTIONS]
+    gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [GH_ISSUE_EDIT_OPTIONS]
     gh ai issue develop <ISSUE_NUMBER> [GH_ISSUE_DEVELOP_OPTIONS]
 
 DESCRIPTION:
-    Creates GitHub issues with AI-generated titles and structured bodies.
-    Develops issues by creating a branch, generating an implementation plan,
-    and opening a pull request.
+    Creates and edits GitHub issues with AI-generated titles and structured
+    bodies. Develops issues by creating a branch, generating an implementation
+    plan, and opening a pull request.
 
 COMMANDS:
     create      Create issues with AI-generated content
+    edit        Edit an existing issue with AI-generated content
     develop     Create a branch and PR with an AI implementation plan
 
 SEE ALSO:
     gh ai issue create --help     # Issue create usage
+    gh ai issue edit --help       # Issue edit usage
     gh ai issue develop --help    # Issue develop usage
 EOF
 }
@@ -85,6 +88,193 @@ _parse_issue_create_args() {
 		esac
 		((++i))
 	done
+}
+
+# Parse issue edit arguments in a single pass
+#
+# Extracts the issue number (first numeric arg), description, and
+# passthrough args for gh issue edit via namerefs.
+# AI-managed flags (--title, --body, --body-file) are stripped.
+#
+# Example: _parse_issue_edit_args num desc args 42 -d "add acceptance criteria" --add-label bug
+_parse_issue_edit_args() {
+	local -n gh_issue_number_ref="$1"
+	local -n gh_issue_description_ref="$2"
+	local -n gh_issue_args_ref="$3"
+	shift 3
+
+	local args=("$@")
+	local skip_next=false
+	local i=0
+
+	while [[ $i -lt ${#args[@]} ]]; do
+		if [ "$skip_next" = true ]; then
+			skip_next=false
+			((++i))
+			continue
+		fi
+
+		case "${args[$i]}" in
+		--description | -d)
+			gh_issue_description_ref="${args[$((i + 1))]}"
+			skip_next=true
+			;;
+		--description=*)
+			gh_issue_description_ref="${args[$i]#--description=}"
+			;;
+		--title | -t | --body | -b | --body-file | -F)
+			skip_next=true
+			;;
+		--title=* | --body=* | --body-file=*) ;;
+		*)
+			if [[ -z "$gh_issue_number_ref" && "${args[$i]}" =~ ^[0-9]+$ ]]; then
+				gh_issue_number_ref="${args[$i]}"
+			else
+				gh_issue_args_ref+=("${args[$i]}")
+			fi
+			;;
+		esac
+		((++i))
+	done
+}
+
+# Issue edit help function
+#
+# Displays help information for the issue edit command
+# including usage examples and available options.
+_show_issue_edit_help() {
+	cat <<'EOF'
+gh ai issue edit - Edit an existing issue with AI-generated content
+
+USAGE:
+    gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [OPTIONS]
+
+DESCRIPTION:
+    Edits an existing GitHub issue using AI. Fetches the current issue
+    content, applies the requested changes via AI, and updates the issue
+    title and body. Supports piped stdin as additional context.
+
+FLAGS:
+    -d, --description string   Description of the changes to make (required)
+
+PASSTHROUGH FLAGS:
+    All other flags are passed directly to gh issue edit.
+    See gh issue edit --help for the full list.
+
+EXAMPLES:
+    gh ai issue edit 42 -d "add acceptance criteria"
+    gh ai issue edit 42 -d "fix typos and improve clarity"
+    gh ai issue edit 42 -d "rephrase as a bug report" --add-label bug
+    some_command 2>&1 | gh ai issue edit 42 -d "add error output"
+EOF
+}
+
+# Issue Edit implementation
+#
+# Edits an existing GitHub issue with AI-generated content.
+# Fetches the current issue, renders a prompt template with the
+# description and issue context, sends it to the AI provider,
+# and updates the issue with the parsed response.
+# Supports piped stdin as additional context.
+#
+# Usage: _gh_issue_edit <ISSUE_NUMBER> -d <DESCRIPTION> [GH_ISSUE_EDIT_OPTIONS]
+_gh_issue_edit() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_issue_edit_help
+		return 0
+		;;
+	esac
+
+	local args=("$@")
+
+	local template_file
+	# shellcheck disable=SC2154
+	template_file="$_gh_ai_source_dir/templates/gh_issue_edit.tmpl"
+
+	local gh_issue_number=""
+	local gh_issue_description=""
+	local gh_issue_args=()
+	_parse_issue_edit_args gh_issue_number gh_issue_description gh_issue_args "${args[@]}"
+
+	if [[ -z "$gh_issue_number" ]]; then
+		gum log --level error "No issue number provided"
+		gum log --level info "Usage: gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [OPTIONS]"
+		return 1
+	fi
+
+	if [[ -z "$gh_issue_description" ]]; then
+		gum log --level error "No description provided"
+		gum log --level info "Usage: gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [OPTIONS]"
+		return 1
+	fi
+
+	# Read piped stdin context if available
+	local gh_issue_context=""
+	if [[ ! -t 0 ]]; then
+		gh_issue_context=$(cat)
+	fi
+
+	# Fetch issue metadata
+	local gh_issue_meta
+	gh_issue_meta=$(gum spin --title "Fetching GitHub issue metadata..." -- \
+		gh issue view "$gh_issue_number" --json title,body,labels,comments || true)
+	if [[ -z "$gh_issue_meta" ]]; then
+		gum log --level error "Failed to fetch issue #$gh_issue_number"
+		return 1
+	fi
+
+	local gh_issue_title
+	gh_issue_title=$(echo "$gh_issue_meta" | jq -r '.title // ""')
+
+	local gh_issue_body
+	gh_issue_body=$(echo "$gh_issue_meta" | jq -r '.body // ""')
+
+	local gh_issue_labels
+	gh_issue_labels=$(echo "$gh_issue_meta" | jq -r '[.labels[].name] | join(", ")')
+
+	local gh_issue_comments
+	gh_issue_comments=$(echo "$gh_issue_meta" | jq -r '[.comments[].body] | join("\n---\n")')
+
+	local agent_model
+	agent_model=$(gh config get gh-ai.issue.model 2>/dev/null || true)
+
+	local output
+	# Generate updated issue content using assistant
+	output=$(
+		gum spin --title "Generating updated GitHub issue..." -- \
+			"$_gh_ai_source_dir/scripts/gh_cmd.sh" assist "$agent_model" < <(
+				GH_ISSUE_NUMBER="$gh_issue_number" GH_ISSUE_TITLE="$gh_issue_title" GH_ISSUE_BODY="$gh_issue_body" GH_ISSUE_LABELS="$gh_issue_labels" GH_ISSUE_COMMENTS="$gh_issue_comments" GH_ISSUE_DESCRIPTION="$gh_issue_description" GH_ISSUE_CONTEXT="$gh_issue_context" \
+					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
+			)
+	)
+
+	# Validate we got issue content
+	if [[ -z "$output" ]]; then
+		gum log --level error "Failed to generate updated issue content"
+		gum log --level info "Run with DEBUG=1 for detailed diagnostics"
+		return 1
+	fi
+
+	local gh_issue_new_title
+	# Parse title from output
+	if ! gh_issue_new_title=$(_get_title "$output"); then
+		gum log --level error "Failed to extract title from AI content"
+		return 1
+	fi
+
+	local gh_issue_new_body
+	# Parse body from output
+	gh_issue_new_body=$(_get_body "$output")
+
+	# Validate we got body content
+	if [[ -z "$gh_issue_new_body" ]]; then
+		gum log --level error "Failed to extract body from AI content"
+		return 1
+	fi
+
+	# Edit issue with AI-generated content
+	gh issue edit "$gh_issue_number" --title "$gh_issue_new_title" --body "$gh_issue_new_body" "${gh_issue_args[@]}"
 }
 
 # Parse issue develop arguments in a single pass
@@ -402,7 +592,7 @@ _gh_issue_create() {
 # Shows help for unknown commands.
 #
 # Usage: _gh_issue <subcommand> [OPTIONS]
-# Subcommands: create, develop, help
+# Subcommands: create, edit, develop, help
 _gh_issue() {
 	local subcommand="${1:-}"
 	shift || true
@@ -410,6 +600,9 @@ _gh_issue() {
 	case $subcommand in
 	create)
 		_gh_issue_create "$@"
+		;;
+	edit)
+		_gh_issue_edit "$@"
 		;;
 	develop)
 		_gh_issue_develop "$@"
@@ -419,7 +612,7 @@ _gh_issue() {
 		;;
 	*)
 		gum log --level error "Unknown issue command '$subcommand'"
-		gum log --level info "Available commands: create, develop"
+		gum log --level info "Available commands: create, edit, develop"
 		gum log --level info "Run 'gh ai issue --help' for usage information"
 		exit 1
 		;;

--- a/templates/gh_issue_edit.tmpl
+++ b/templates/gh_issue_edit.tmpl
@@ -1,0 +1,35 @@
+Edit the following GitHub issue based on the requested changes.
+
+<issue>
+Number: {{ param "GH_ISSUE_NUMBER" }}
+Title: {{ param "GH_ISSUE_TITLE" }}
+Body: {{ param "GH_ISSUE_BODY" }}
+Labels: {{ param "GH_ISSUE_LABELS" }}
+</issue>
+
+<comments>
+{{ param "GH_ISSUE_COMMENTS" }}
+</comments>
+
+<requested_changes>
+{{ param "GH_ISSUE_DESCRIPTION" }}
+</requested_changes>
+
+<additional_context>
+{{ param "GH_ISSUE_CONTEXT" }}
+</additional_context>
+
+<format>
+- First line: issue title — `# {title}`, clear and specific, under 72 chars
+- Body: GitHub-flavored Markdown
+- Apply only the requested changes; preserve everything else
+- Adapt structure to bug vs feature based on the content
+- Omit sections that do not apply; do not write "N/A"
+- Output only the issue content, no preamble or commentary
+</format>
+
+<body>
+# {title}
+
+{updated issue body incorporating the requested changes}
+</body>


### PR DESCRIPTION
## Summary

Introduces a new `gh ai issue edit` subcommand that fetches an existing GitHub issue, sends its content along with a user-provided change description to the AI provider, and updates the issue title and body with the generated result. This rounds out the issue workflow alongside `create` and `develop`, enabling quick AI-driven edits like adding acceptance criteria, fixing typos, or restructuring an issue as a bug report.

## Risk Level

- [x] Low (docs, tests, internal refactor)
- [ ] Medium (behavior change, non-critical path)
- [ ] High (core logic, data integrity, security, perf-critical)

## Changes

### Behavior & Execution Flow

Running `gh ai issue edit 42 -d "add acceptance criteria"` will:
1. Parse the issue number, description (`-d`), and passthrough flags while stripping AI-managed flags (`--title`, `--body`, `--body-file`) — `scripts/gh_issue.sh:93-131`.
2. Fetch the issue's title, body, labels, and comments via `gh issue view --json` — `scripts/gh_issue.sh:210-221`.
3. Render `templates/gh_issue_edit.tmpl` with the fetched metadata, user description, and optional piped stdin context, then send it to the AI assistant — `scripts/gh_issue.sh:232-237`.
4. Parse the AI response into a new title and body using the existing `_get_title` / `_get_body` helpers — `scripts/gh_issue.sh:247-259`.
5. Call `gh issue edit` with the generated title/body and any passthrough flags (e.g., `--add-label`) — `scripts/gh_issue.sh:267`.

The `_gh_issue` dispatcher (`scripts/gh_issue.sh:601`) routes the `edit` subcommand, and help text / error messages are updated to reflect the new command.

### Design Decisions

- **Same patterns as `issue create`**: argument parsing via namerefs, spinner-wrapped API calls, and template-driven prompts keep the codebase consistent.
- **Passthrough-first flag handling**: unknown flags flow directly to `gh issue edit`, so users get full access to the native CLI options (`--add-label`, `--milestone`, etc.) without duplication.
- **Preserve-by-default prompt**: the template (`templates/gh_issue_edit.tmpl:28`) instructs the AI to apply only the requested changes and keep everything else, minimising unwanted rewrites.
- **Piped stdin support**: allows users to feed error output or other context (e.g., `some_command 2>&1 | gh ai issue edit 42 -d "add error output"`).

### Edge Cases

- Missing issue number or description exits with a clear error and usage hint — `scripts/gh_issue.sh:191-200`.
- Failed `gh issue view` (wrong number, permissions) is caught by checking for empty metadata — `scripts/gh_issue.sh:214-217`.
- Empty AI output or unparseable title/body each produce distinct error messages — `scripts/gh_issue.sh:241-259`.
- AI-managed flags (`--title`, `--body`, `--body-file`) are silently stripped to prevent conflicts with the generated content.

## Testing

```bash
# Basic edit
gh ai issue edit <ISSUE_NUMBER> -d "add acceptance criteria"

# Edit with passthrough flags
gh ai issue edit <ISSUE_NUMBER> -d "rephrase as a bug report" --add-label bug

# Piped context
echo "segfault at 0x0" | gh ai issue edit <ISSUE_NUMBER> -d "add crash details"

# Help output
gh ai issue edit --help

# Error cases
gh ai issue edit -d "missing number"      # should error: no issue number
gh ai issue edit 42                        # should error: no description
```

## Impact

- **Breaking Changes:** No — additive subcommand; existing `create` and `develop` paths are untouched.
- **Performance:** No change — one additional `gh issue view` call only when `edit` is invoked.
- **Security:** Follows the same trust model as `issue create`; all data flows through the user's configured AI provider and authenticated `gh` CLI.