### PR TITLE
Improve `gh ai pr` command with edit subcommand and optional description flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 # gh-ai
 
 A GitHub CLI extension that uses AI to generate commit messages, pull request
-descriptions, code reviews, PR explanations, structured issues, issue edits,
-and implementation plans.
+descriptions and edits, code reviews, PR explanations, structured issues,
+issue edits, and implementation plans.
 
 ![License](https://img.shields.io/github/license/gh-extensions/gh-ai)
 ![Version](https://img.shields.io/github/v/release/gh-extensions/gh-ai)
@@ -26,7 +26,8 @@ gh extension install gh-extensions/gh-ai
 
 ```bash
 gh ai commit [GIT_COMMIT_OPTIONS]
-gh ai pr create [GH_PR_CREATE_OPTIONS]
+gh ai pr create [-d <DESCRIPTION>] [GH_PR_CREATE_OPTIONS]
+gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [GH_PR_EDIT_OPTIONS]
 gh ai pr review [PR_NUMBER] [GH_PR_REVIEW_OPTIONS]
 gh ai pr explain [PR_NUMBER] [--comment | --edit]
 gh ai issue create -d <DESCRIPTION> [GH_ISSUE_CREATE_OPTIONS]
@@ -52,6 +53,16 @@ Creates a pull request with an AI-generated title and description.
 ```bash
 gh ai pr create
 gh ai pr create --draft --base develop
+gh ai pr create -d "focus on the security changes"
+```
+
+Edits an existing pull request with AI-generated updates based on a description
+of what to change.
+
+```bash
+gh ai pr edit 42 -d "add testing section"
+gh ai pr edit 42 -d "fix summary" --add-label bug
+gh ai pr edit -d "improve description"   # auto-detect PR from current branch
 ```
 
 Reviews a pull request with AI-generated feedback.
@@ -116,7 +127,7 @@ Override the AI provider and model via `gh config`.
 | `gh-ai.provider`     | `anthropic` | AI provider (`anthropic`)                     |
 | `gh-ai.model`        | `haiku`     | Model for all commands (fallback)             |
 | `gh-ai.commit.model` |             | Model override for `commit`                   |
-| `gh-ai.pr.model`     |             | Model override for `pr create/review/explain` |
+| `gh-ai.pr.model`     |             | Model override for `pr create/edit/review/explain` |
 | `gh-ai.issue.model`  |             | Model override for `issue create/edit/develop` |
 | `gh-ai.run.model`    |             | Model override for `run explain`              |
 

--- a/gh-ai
+++ b/gh-ai
@@ -59,7 +59,7 @@ USAGE:
     gh ai <command> [subcommand] [options]
 
 COMMANDS:
-    pr          Pull request operations (create, review, explain)
+    pr          Pull request operations (create, edit, review, explain)
     commit      Generate a commit message for staged changes
     issue       Issue operations (create, edit, develop)
     run         Workflow run operations (explain)

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -8,15 +8,17 @@ set -euo pipefail
 
 # Parse PR create arguments in a single pass
 #
-# Extracts the --base branch value and passthrough args for gh pr create
-# via namerefs. --base passes through AND is captured for git diff.
-# AI-managed flags (--title, --body, --body-file, --template, --fill*) are stripped.
+# Extracts the --base branch value, optional description, and passthrough
+# args for gh pr create via namerefs. --base passes through AND is captured
+# for git diff. AI-managed flags (--title, --body, --body-file, --template,
+# --fill*) are stripped.
 #
-# Example: _parse_pr_create_args base args --base develop --draft
+# Example: _parse_pr_create_args base desc args --base develop --draft
 _parse_pr_create_args() {
 	local -n git_base_branch_ref="$1"
-	local -n gh_pr_args_ref="$2"
-	shift 2
+	local -n gh_pr_description_ref="$2"
+	local -n gh_pr_args_ref="$3"
+	shift 3
 
 	local args=("$@")
 	local skip_next=false
@@ -30,6 +32,13 @@ _parse_pr_create_args() {
 		fi
 
 		case "${args[$i]}" in
+		--description | -d)
+			gh_pr_description_ref="${args[$((i + 1))]}"
+			skip_next=true
+			;;
+		--description=*)
+			gh_pr_description_ref="${args[$i]#--description=}"
+			;;
 		--base | -B)
 			git_base_branch_ref="${args[$((i + 1))]}"
 			gh_pr_args_ref+=("${args[$i]}" "${args[$((i + 1))]}")
@@ -61,20 +70,24 @@ _show_pr_create_help() {
 gh ai pr create - Create PRs with AI-generated titles and descriptions
 
 USAGE:
-    gh ai pr create [OPTIONS]
+    gh ai pr create [-d <DESCRIPTION>] [OPTIONS]
 
 DESCRIPTION:
     Creates a GitHub pull request with an AI-generated title and description
     based on the diff and commit history between the current and base branch.
 
+FLAGS:
+    -d, --description string   Optional guidance for the AI (e.g. focus area)
+
 PASSTHROUGH FLAGS:
-    All flags are passed directly to gh pr create.
+    All other flags are passed directly to gh pr create.
     See gh pr create --help for the full list.
 
 EXAMPLES:
     gh ai pr create
     gh ai pr create --draft
     gh ai pr create --draft --base develop
+    gh ai pr create -d "focus on the security changes"
 EOF
 }
 
@@ -100,8 +113,9 @@ _gh_pr_create() {
 	template_file="$_gh_ai_source_dir/templates/gh_pr_create.tmpl"
 
 	local git_base_branch=""
+	local gh_pr_description=""
 	local gh_pr_args=()
-	_parse_pr_create_args git_base_branch gh_pr_args "${args[@]}"
+	_parse_pr_create_args git_base_branch gh_pr_description gh_pr_args "${args[@]}"
 
 	local git_head_branch
 	git_head_branch=$(git rev-parse --abbrev-ref HEAD)
@@ -147,7 +161,7 @@ _gh_pr_create() {
 	output=$(
 		gum spin --title "Generating GitHub pull request..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" assist "$agent_model" < <(
-				GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" GIT_LOG="$git_log" GIT_COMMITS="$git_log_oneline" \
+				GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" GIT_LOG="$git_log" GIT_COMMITS="$git_log_oneline" GH_PR_DESCRIPTION="$gh_pr_description" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -178,6 +192,201 @@ _gh_pr_create() {
 
 	# Create PR with AI-generated content
 	gh pr create --title "$gh_pr_title" --body "$gh_pr_body" "${gh_pr_args[@]}"
+}
+
+# Parse PR edit arguments in a single pass
+#
+# Extracts the PR number (first numeric arg, with auto-detect fallback),
+# description, and passthrough args for gh pr edit via namerefs.
+# AI-managed flags (--title, --body, --body-file) are stripped.
+#
+# Example: _parse_pr_edit_args num desc args 42 -d "add testing section" --add-label bug
+_parse_pr_edit_args() {
+	local -n gh_pr_number_ref="$1"
+	local -n gh_pr_description_ref="$2"
+	local -n gh_pr_args_ref="$3"
+	shift 3
+
+	local args=("$@")
+	local skip_next=false
+	local i=0
+
+	while [[ $i -lt ${#args[@]} ]]; do
+		if [ "$skip_next" = true ]; then
+			skip_next=false
+			((++i))
+			continue
+		fi
+
+		case "${args[$i]}" in
+		--description | -d)
+			gh_pr_description_ref="${args[$((i + 1))]}"
+			skip_next=true
+			;;
+		--description=*)
+			gh_pr_description_ref="${args[$i]#--description=}"
+			;;
+		--title | -t | --body | -b | --body-file | -F)
+			skip_next=true
+			;;
+		--title=* | --body=* | --body-file=*) ;;
+		*)
+			if [[ -z "$gh_pr_number_ref" && "${args[$i]}" =~ ^[0-9]+$ ]]; then
+				gh_pr_number_ref="${args[$i]}"
+			else
+				gh_pr_args_ref+=("${args[$i]}")
+			fi
+			;;
+		esac
+		((++i))
+	done
+
+	# Auto-detect PR number from current branch if not found in args
+	if [[ -z "$gh_pr_number_ref" ]]; then
+		gh_pr_number_ref=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+	fi
+}
+
+# PR edit help function
+#
+# Displays help information for the PR edit command
+# including usage examples and available options.
+_show_pr_edit_help() {
+	cat <<'EOF'
+gh ai pr edit - Edit an existing PR with AI-generated content
+
+USAGE:
+    gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [OPTIONS]
+
+DESCRIPTION:
+    Edits an existing GitHub pull request using AI. Fetches the current PR
+    content and diff, applies the requested changes via AI, and updates the
+    PR title and body. Auto-detects PR from the current branch if no number
+    is provided.
+
+FLAGS:
+    -d, --description string   Description of the changes to make (required)
+
+PASSTHROUGH FLAGS:
+    All other flags are passed directly to gh pr edit.
+    See gh pr edit --help for the full list.
+
+EXAMPLES:
+    gh ai pr edit 42 -d "add testing section"
+    gh ai pr edit 42 -d "fix summary" --add-label bug
+    gh ai pr edit -d "improve description"   # auto-detect PR from current branch
+EOF
+}
+
+# PR Edit implementation
+#
+# Edits an existing GitHub PR with AI-generated content.
+# Fetches the current PR content and diff, renders a prompt template
+# with the description and PR context, sends it to the AI provider,
+# and updates the PR with the parsed response.
+#
+# Usage: _gh_pr_edit [PR_NUMBER] -d <DESCRIPTION> [GH_PR_EDIT_OPTIONS]
+_gh_pr_edit() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_pr_edit_help
+		return 0
+		;;
+	esac
+
+	local args=("$@")
+
+	local template_file
+	# shellcheck disable=SC2154
+	template_file="$_gh_ai_source_dir/templates/gh_pr_edit.tmpl"
+
+	local gh_pr_number=""
+	local gh_pr_description=""
+	local gh_pr_args=()
+	_parse_pr_edit_args gh_pr_number gh_pr_description gh_pr_args "${args[@]}"
+
+	if [[ -z "$gh_pr_number" ]]; then
+		gum log --level error "No PR number provided and could not detect PR for current branch"
+		gum log --level info "Usage: gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [OPTIONS]"
+		return 1
+	fi
+
+	if [[ -z "$gh_pr_description" ]]; then
+		gum log --level error "No description provided"
+		gum log --level info "Usage: gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [OPTIONS]"
+		return 1
+	fi
+
+	# Fetch PR metadata
+	local gh_pr_meta
+	gh_pr_meta=$(gum spin --title "Fetching GitHub pull request metadata..." -- \
+		gh pr view "$gh_pr_number" --json title,body || true)
+	if [[ -z "$gh_pr_meta" ]]; then
+		gum log --level error "Failed to fetch PR #$gh_pr_number"
+		return 1
+	fi
+
+	local gh_pr_title
+	gh_pr_title=$(echo "$gh_pr_meta" | jq -r '.title // ""')
+
+	local gh_pr_body
+	gh_pr_body=$(echo "$gh_pr_meta" | jq -r '.body // ""')
+
+	# Get PR diff using gh cli (--patch for full patch format)
+	local git_diff
+	git_diff=$(gum spin --title "Fetching GitHub pull request diff..." -- \
+		gh pr diff "$gh_pr_number" --patch || true)
+	if [[ -z "$git_diff" ]]; then
+		gum log --level error "Failed to get diff for PR #$gh_pr_number"
+		return 1
+	fi
+
+	local git_diff_stat
+	git_diff_stat=$(echo "$git_diff" | git apply --stat 2>/dev/null || true)
+
+	local git_commit_list
+	git_commit_list=$(gum spin --title "Fetching GitHub pull request commits..." -- \
+		gh pr view "$gh_pr_number" --json commits -q '.commits[] | "- " + .messageHeadline' || true)
+
+	local agent_model
+	agent_model=$(gh config get gh-ai.pr.model 2>/dev/null || true)
+
+	local output
+	# Generate updated PR content using assistant
+	output=$(
+		gum spin --title "Generating updated GitHub pull request..." -- \
+			"$_gh_ai_source_dir/scripts/gh_cmd.sh" assist "$agent_model" < <(
+				GH_PR_NUMBER="$gh_pr_number" GH_PR_TITLE="$gh_pr_title" GH_PR_BODY="$gh_pr_body" GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" GIT_COMMITS="$git_commit_list" GH_PR_DESCRIPTION="$gh_pr_description" \
+					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
+			)
+	)
+
+	# Validate we got PR content
+	if [[ -z "$output" ]]; then
+		gum log --level error "Failed to generate updated pull request content"
+		gum log --level info "Run with DEBUG=1 for detailed diagnostics"
+		return 1
+	fi
+
+	local gh_pr_new_title
+	# Parse title from output
+	if ! gh_pr_new_title=$(_get_title "$output"); then
+		gum log --level error "Failed to extract title from AI content"
+		return 1
+	fi
+
+	local gh_pr_new_body
+	# Parse body from output
+	gh_pr_new_body=$(_get_body "$output")
+
+	# Validate we got body content
+	if [[ -z "$gh_pr_new_body" ]]; then
+		gum log --level error "Failed to extract body from AI content"
+		return 1
+	fi
+
+	# Edit PR with AI-generated content
+	gh pr edit "$gh_pr_number" --title "$gh_pr_new_title" --body "$gh_pr_new_body" "${gh_pr_args[@]}"
 }
 
 # Parse PR explain arguments in a single pass
@@ -494,20 +703,23 @@ _show_pr_help() {
 gh ai pr - Pull request commands with AI assistance
 
 USAGE:
-    gh ai pr create [GH_PR_CREATE_OPTIONS]
+    gh ai pr create [-d <DESCRIPTION>] [GH_PR_CREATE_OPTIONS]
+    gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [GH_PR_EDIT_OPTIONS]
     gh ai pr review [PR_NUMBER] [GH_PR_REVIEW_OPTIONS]
     gh ai pr explain [PR_NUMBER] [--comment | --edit]
 
 DESCRIPTION:
-    Creates, reviews, and explains GitHub pull requests with AI-generated content.
+    Creates, edits, reviews, and explains GitHub pull requests with AI-generated content.
 
 COMMANDS:
     create      Create PRs with AI-generated titles and descriptions
+    edit        Edit an existing PR with AI-generated content
     review      Review PRs with AI-generated feedback
     explain     Generate a plain-language explanation of a PR
 
 SEE ALSO:
     gh ai pr create --help     # Full list of gh pr create options
+    gh ai pr edit --help       # Full list of gh pr edit options
     gh ai pr review --help     # Full list of gh pr review options
     gh ai pr explain --help    # PR explain usage
 EOF
@@ -519,7 +731,7 @@ EOF
 # Shows help for unknown commands.
 #
 # Usage: _gh_pr <subcommand> [OPTIONS]
-# Subcommands: create, review, explain, help
+# Subcommands: create, edit, review, explain, help
 _gh_pr() {
 	local subcommand="${1:-}"
 	shift || true
@@ -527,6 +739,9 @@ _gh_pr() {
 	case $subcommand in
 	create)
 		_gh_pr_create "$@"
+		;;
+	edit)
+		_gh_pr_edit "$@"
 		;;
 	review)
 		_gh_pr_review "$@"
@@ -539,7 +754,7 @@ _gh_pr() {
 		;;
 	*)
 		gum log --level error "Unknown pr command '$subcommand'"
-		gum log --level info "Available commands: create, review, explain"
+		gum log --level info "Available commands: create, edit, review, explain"
 		gum log --level info "Run 'gh ai pr --help' for usage information"
 		exit 1
 		;;

--- a/templates/gh_pr_create.tmpl
+++ b/templates/gh_pr_create.tmpl
@@ -1,4 +1,5 @@
 Write a GitHub pull request title and body for the changes below.
+If a description is provided, use it as guidance for emphasis and framing.
 
 <diffstat>
 {{ param "GIT_DIFF_STAT" }}
@@ -17,6 +18,10 @@ Write a GitHub pull request title and body for the changes below.
 {{ param "GIT_COMMITS" }}
 </recent_commits>
 </context>
+
+<description>
+{{ param "GH_PR_DESCRIPTION" }}
+</description>
 
 <format>
 - First line: PR title — imperative mood, under 72 chars, no trailing period

--- a/templates/gh_pr_edit.tmpl
+++ b/templates/gh_pr_edit.tmpl
@@ -1,0 +1,37 @@
+Edit the following GitHub pull request based on the requested changes.
+
+<pull_request>
+Number: {{ param "GH_PR_NUMBER" }}
+Title: {{ param "GH_PR_TITLE" }}
+Body: {{ param "GH_PR_BODY" }}
+</pull_request>
+
+<diffstat>
+{{ param "GIT_DIFF_STAT" }}
+</diffstat>
+
+<diff>
+{{ param "GIT_DIFF" }}
+</diff>
+
+<commits>
+{{ param "GIT_COMMITS" }}
+</commits>
+
+<requested_changes>
+{{ param "GH_PR_DESCRIPTION" }}
+</requested_changes>
+
+<format>
+- First line: PR title — `# {title}`, imperative mood, under 72 chars, no trailing period
+- Body: GitHub-flavored Markdown; reference code as `file.ext:line`
+- Apply only the requested changes; preserve everything else
+- Omit sections that do not apply; do not write "N/A"
+- Output only the PR content, no preamble or commentary
+</format>
+
+<body>
+# {title}
+
+{updated PR body incorporating the requested changes}
+</body>


### PR DESCRIPTION
## Summary

Enhances the `gh ai pr` command by introducing a new `edit` subcommand that updates an existing pull request's title and body using AI, based on a user-provided description of the desired changes. Also adds an optional `-d`/`--description` flag to `gh ai pr create` so users can guide the AI's focus when generating new PR content.

## Risk Level

- [ ] Low (docs, tests, internal refactor)
- [x] Medium (behavior change, non-critical path)
- [ ] High (core logic, data integrity, security, perf-critical)

## Changes

### Behavior & Execution Flow

- **`gh ai pr create`** now accepts `-d <DESCRIPTION>` to pass optional guidance to the AI prompt template. The description is injected into `gh_pr_create.tmpl` via the `GH_PR_DESCRIPTION` parameter. Existing behavior without `-d` is unchanged.
- **`gh ai pr edit`** fetches the current PR metadata (title, body), diff, and commit list via `gh pr view` and `gh pr diff`, renders them through a new `gh_pr_edit.tmpl` template alongside the user's requested changes, and calls the AI provider to produce an updated title and body. The result is applied with `gh pr edit --title --body`, and any additional flags (e.g. `--add-label`) are passed through.
- Auto-detection of the PR number from the current branch is supported when no explicit number is given, using `gh pr view --json number`.
- `_parse_pr_create_args` gains a third nameref parameter for the description; `_parse_pr_edit_args` is a new parser that extracts PR number, description, and passthrough args while stripping AI-managed flags (`--title`, `--body`, `--body-file`).

### Design Decisions

- Reuses the existing `_get_title` / `_get_body` helpers and `assist` / `render` pipeline so `pr edit` follows the same pattern as `pr create`.
- The edit template instructs the AI to apply only the requested changes and preserve everything else, minimizing unintended rewrites.
- `-d`/`--description` was chosen as the flag name to stay consistent with the existing convention used in `issue create` and `issue edit`.

### Edge Cases

- If no PR number is supplied and the current branch has no associated PR, the command exits with a clear error message.
- If the description flag is omitted for `pr edit`, the command exits with a usage hint since the description is required.
- Empty AI output or failure to parse title/body results in descriptive error messages with a `DEBUG=1` hint.

## Testing

```bash
# Create with description guidance
gh ai pr create --draft -d "focus on the security changes"

# Edit by PR number
gh ai pr edit 42 -d "add testing section"

# Edit with passthrough flags
gh ai pr edit 42 -d "fix summary" --add-label bug

# Auto-detect PR from current branch
gh ai pr edit -d "improve description"

# Help output
gh ai pr edit --help
gh ai pr create --help
```

## Impact

- **Breaking Changes:** No — `pr create` without `-d` behaves identically to before; the additional nameref in `_parse_pr_create_args` is internal.
- **Performance:** No change — one extra template parameter when `-d` is used; `pr edit` makes the same number of API calls as `pr explain`.
- **Security:** No new auth scopes required; uses existing `gh` CLI credentials.