### PR TITLE
Add --remote option to gh ai issue develop

### DIFF
--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -95,6 +95,10 @@ _cmd_assist_remotely() {
 	@copilot)
 		echo "$prompt" | gh agent-task create -R "$repo" -F -
 		;;
+	*)
+		gum log --level error "Unknown agent '$handle' (supported: @claude, @jules, @copilot)"
+		return 1
+		;;
 	esac
 }
 

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -72,6 +72,32 @@ _cmd_assist() {
 	esac
 }
 
+# Invoke a remote AI agent CLI with a prompt
+#
+# Dispatches to the appropriate agent CLI based on the GitHub mention handle:
+#   @claude  -> claude --remote        (prompt via stdin)
+#   @jules   -> jules remote new       (prompt via --session, --repo)
+#   @copilot -> gh agent-task create   (prompt via stdin with -F -, -R)
+#
+# Usage: _cmd_assist_remotely <handle> <repo> <prompt>
+_cmd_assist_remotely() {
+	local handle="$1"
+	local repo="$2"
+	local prompt="$3"
+
+	case "$handle" in
+	@claude)
+		echo "$prompt" | claude --remote
+		;;
+	@jules)
+		jules remote new --repo "$repo" --session "$prompt"
+		;;
+	@copilot)
+		echo "$prompt" | gh agent-task create -R "$repo" -F -
+		;;
+	esac
+}
+
 # Extract title from AI response
 #
 # Gets the title from AI-generated content by taking the first line
@@ -149,8 +175,11 @@ main() {
 	assist)
 		_cmd_assist "${2:-}"
 		;;
+	remotely)
+		_cmd_assist_remotely "${2:-}" "${3:-}" "${4:-}"
+		;;
 	*)
-		gum log --level error "Usage: gh_cmd.sh <render|assist> [args]"
+		gum log --level error "Usage: gh_cmd.sh <render|assist|remotely> [args]"
 		exit 1
 		;;
 	esac

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -265,18 +265,20 @@ _gh_issue_edit() {
 
 # Parse issue develop arguments (before -- separator)
 #
-# Extracts the issue number (first numeric arg), -c/--checkout flag, and
-# gh issue develop scalars (-b/--base, -n/--name, --branch-repo).
+# Extracts the issue number (first numeric arg), -c/--checkout flag,
+# gh issue develop scalars (-b/--base, -n/--name, --branch-repo), and
+# the --agent handle (@claude, @copilot, @jules).
 # Unknown flags produce an error with a hint to use --.
 #
-# Example: _parse_issue_develop_args num checkout base name branch_repo 42 -c -b develop
+# Example: _parse_issue_develop_args num checkout base name branch_repo agent 42 -c -b develop
 _parse_issue_develop_args() {
 	local -n gh_issue_number_ref="$1"
 	local -n gh_checkout_ref="$2"
 	local -n gh_develop_base_ref="$3"
 	local -n gh_develop_name_ref="$4"
 	local -n gh_develop_branch_repo_ref="$5"
-	shift 5
+	local -n gh_agent_ref="$6"
+	shift 6
 
 	local raw_args=("$@")
 	local skip_next=false
@@ -331,6 +333,18 @@ _parse_issue_develop_args() {
 			# shellcheck disable=SC2034
 			gh_checkout_ref=true
 			;;
+		--agent)
+			if ((i + 1 >= ${#raw_args[@]})); then
+				echo "error: ${raw_args[$i]} requires a value" >&2
+				return 1
+			fi
+			gh_agent_ref="${raw_args[$((i + 1))]}"
+			skip_next=true
+			;;
+		--agent=*)
+			# shellcheck disable=SC2034
+			gh_agent_ref="${raw_args[$i]#--agent=}"
+			;;
 		-*)
 			echo "error: unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr create)" >&2
 			return 1
@@ -357,7 +371,7 @@ _show_issue_develop_help() {
 gh ai issue develop - Create a branch and PR with an AI implementation plan
 
 USAGE:
-    gh ai issue develop <ISSUE_NUMBER> [-c] [-b BASE] [-n NAME] [--branch-repo REPO] [-- GH_PR_CREATE_OPTIONS]
+    gh ai issue develop <ISSUE_NUMBER> [-c] [-b BASE] [-n NAME] [--branch-repo REPO] [--agent HANDLE] [-- OPTIONS]
 
 DESCRIPTION:
     Creates a development branch from a GitHub issue, generates an AI
@@ -367,22 +381,116 @@ DESCRIPTION:
     (pull request). Title and body are AI-generated from the issue.
     Options after -- are passed directly to gh pr create.
 
+    With --agent, the AI-generated plan is passed as a prompt to the
+    specified agent CLI. No branch or PR is created locally.
+
 BRANCH FLAGS (gh issue develop):
     -b, --base string          Name of the remote branch to branch from
     -n, --name string          Name of the branch to create
         --branch-repo string   Name or URL of the repo for the new branch
 
 WORKFLOW FLAGS:
-    -c, --checkout   Check out the new branch locally after creating it.
-                     Default: branch is created remotely and an initial commit
-                     is added without switching your working tree.
+    -c, --checkout             Check out the new branch locally after creating it.
+                               Default: branch is created remotely and an initial commit
+                               is added without switching your working tree.
+        --agent HANDLE         Delegate implementation to a remote AI agent.
+                               Supported: @claude, @copilot, @jules
 
 EXAMPLES:
     gh ai issue develop 42
     gh ai issue develop 42 --checkout
     gh ai issue develop 42 -b develop -- --draft
     gh ai issue develop 42 -- --label enhancement --reviewer monalisa
+    gh ai issue develop 42 --agent @claude
+    gh ai issue develop 42 --agent @copilot
+    gh ai issue develop 42 --agent @jules
 EOF
+}
+
+# Delegate issue development to a remote AI agent.
+#
+# Renders the agent instruction template from the AI-generated plan and
+# pipes the result to the appropriate agent CLI via _cmd_assist_remotely.
+# No branch or PR is created locally — the agent handles everything.
+#
+# Usage: _gh_issue_develop_remotely <agent> <issue_number> <pr_title> <pr_body>
+_gh_issue_develop_remotely() {
+	local gh_agent="$1"
+	local gh_issue_number="$2"
+	local gh_pr_title="$3"
+	local gh_pr_body="$4"
+
+	local agent_template_file
+	# shellcheck disable=SC2154
+	agent_template_file="$_gh_ai_source_dir/templates/gh_issue_develop_agent.tmpl"
+
+	local agent_prompt
+	agent_prompt=$(
+		GH_PR_TITLE="$gh_pr_title" GH_PR_BODY="$gh_pr_body" \
+			"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$agent_template_file"
+	)
+
+	local gh_repo
+	gh_repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+
+	gum spin --title "Delegating GitHub issue #$gh_issue_number to $gh_agent..." -- \
+		"$_gh_ai_source_dir/scripts/gh_cmd.sh" remotely "$gh_agent" "$gh_repo" "$agent_prompt"
+
+	gum log --level info "GitHub Issue #$gh_issue_number delegated to $gh_agent"
+}
+
+# No-checkout develop path: create branch remotely via commit-tree
+#
+# Creates the development branch using `gh issue develop`, adds an initial
+# empty commit via git commit-tree without switching the local working tree,
+# then opens a pull request with --head set to the new branch.
+#
+# Usage: _gh_issue_develop_no_checkout <issue_number> <pr_title> <pr_body> <issue_args_name> <passthrough_name>
+_gh_issue_develop_no_checkout() {
+	local gh_issue_number="$1"
+	local gh_pr_title="$2"
+	local gh_pr_body="$3"
+	local -n _issue_args_ref="$4"
+	local -n _passthrough_ref="$5"
+
+	local gh_develop_url
+	gh_develop_url=$(gum spin --title "Creating Git branch #$gh_issue_number..." -- \
+		gh issue develop "$gh_issue_number" "${_issue_args_ref[@]}")
+	if [[ -z "$gh_develop_url" ]]; then
+		gum log --level error "Failed to create development branch for #$gh_issue_number"
+		return 1
+	fi
+
+	# gh issue develop outputs a GitHub web URL ending with /tree/<branch>.
+	# Strip the prefix rather than using basename to handle branch names
+	# that contain '/' (e.g. feature/my-topic).
+	local git_branch_name
+	git_branch_name="${gh_develop_url##*/tree/}"
+	if [[ -z "$git_branch_name" ]]; then
+		gum log --level error "Failed to determine branch name from: $gh_develop_url"
+		return 1
+	fi
+
+	gum spin --title "Fetching Git branch $git_branch_name..." -- \
+		git fetch origin "$git_branch_name"
+
+	local git_tree_sha
+	# shellcheck disable=SC1083  # braces are git rev-parse syntax, not a shell expansion
+	git_tree_sha=$(git rev-parse FETCH_HEAD^{tree})
+
+	local git_parent_sha
+	git_parent_sha=$(git rev-parse FETCH_HEAD)
+
+	local git_commit_sha
+	git_commit_sha=$(git commit-tree "$git_tree_sha" -p "$git_parent_sha" \
+		-m "chore: start work on #$gh_issue_number")
+
+	gum spin --title "Pushing Git initial commit..." -- \
+		git push origin "$git_commit_sha:refs/heads/$git_branch_name"
+
+	# Create the pull request, explicitly naming the head branch
+	gh pr create --title "$gh_pr_title" --body "$gh_pr_body" \
+		--head "$git_branch_name" "${_passthrough_ref[@]}"
 }
 
 # Issue Develop implementation
@@ -391,7 +499,7 @@ EOF
 # plan, and opens a pull request with that plan as the body.
 # Uses native `gh issue develop` for branch creation.
 #
-# Usage: _gh_issue_develop <NUMBER> [-c] [-b BASE] [-n NAME] [--branch-repo REPO] [-- OPTIONS]
+# Usage: _gh_issue_develop <ISSUE_NUMBER> [-c] [-b BASE] [-n NAME] [--branch-repo REPO] [--agent HANDLE] [-- OPTIONS]
 _gh_issue_develop() {
 	case "${1:-}" in
 	--help | -h | help)
@@ -413,7 +521,18 @@ _gh_issue_develop() {
 	local gh_develop_base=""
 	local gh_develop_name=""
 	local gh_develop_branch_repo=""
-	_parse_issue_develop_args gh_issue_number gh_checkout gh_develop_base gh_develop_name gh_develop_branch_repo "${ai_args[@]}"
+	local gh_agent=""
+	_parse_issue_develop_args gh_issue_number gh_checkout gh_develop_base gh_develop_name gh_develop_branch_repo gh_agent "${ai_args[@]}"
+
+	if [[ -n "$gh_agent" ]]; then
+		case "$gh_agent" in
+		@claude | @jules | @copilot) ;;
+		*)
+			gum log --level error "Unknown agent '$gh_agent' (supported: @claude, @jules, @copilot)"
+			return 1
+			;;
+		esac
+	fi
 
 	# Build gh issue develop args from scalars
 	local gh_issue_args=()
@@ -477,6 +596,11 @@ _gh_issue_develop() {
 		return 1
 	fi
 
+	if [[ -n "$gh_agent" ]]; then
+		_gh_issue_develop_remotely "$gh_agent" "$gh_issue_number" "$gh_pr_title" "$gh_pr_body"
+		return 0
+	fi
+
 	if [ "$gh_checkout" = "true" ]; then
 		# Standard approach: checkout branch locally
 		gum spin --title "Creating Git branch #$gh_issue_number..." -- \
@@ -489,46 +613,7 @@ _gh_issue_develop() {
 		# Create the pull request
 		gh pr create --title "$gh_pr_title" --body "$gh_pr_body" "${passthrough[@]}"
 	else
-		# No-checkout approach: create the branch remotely, then add an initial
-		# commit via git commit-tree without switching the local working tree.
-		local gh_develop_url
-		gh_develop_url=$(gum spin --title "Creating Git branch #$gh_issue_number..." -- \
-			gh issue develop "$gh_issue_number" "${gh_issue_args[@]}")
-		if [[ -z "$gh_develop_url" ]]; then
-			gum log --level error "Failed to create development branch for #$gh_issue_number"
-			return 1
-		fi
-
-		# gh issue develop outputs a GitHub web URL ending with /tree/<branch>.
-		# Strip the prefix rather than using basename to handle branch names
-		# that contain '/' (e.g. feature/my-topic).
-		local git_branch_name
-		git_branch_name="${gh_develop_url##*/tree/}"
-		if [[ -z "$git_branch_name" ]]; then
-			gum log --level error "Failed to determine branch name from: $gh_develop_url"
-			return 1
-		fi
-
-		gum spin --title "Fetching Git branch $git_branch_name..." -- \
-			git fetch origin "$git_branch_name"
-
-		local git_tree_sha
-		# shellcheck disable=SC1083  # braces are git rev-parse syntax, not a shell expansion
-		git_tree_sha=$(git rev-parse FETCH_HEAD^{tree})
-
-		local git_parent_sha
-		git_parent_sha=$(git rev-parse FETCH_HEAD)
-
-		local git_commit_sha
-		git_commit_sha=$(git commit-tree "$git_tree_sha" -p "$git_parent_sha" \
-			-m "chore: start work on #$gh_issue_number")
-
-		gum spin --title "Pushing Git initial commit..." -- \
-			git push origin "$git_commit_sha:refs/heads/$git_branch_name"
-
-		# Create the pull request, explicitly naming the head branch
-		gh pr create --title "$gh_pr_title" --body "$gh_pr_body" \
-			--head "$git_branch_name" "${passthrough[@]}"
+		_gh_issue_develop_no_checkout "$gh_issue_number" "$gh_pr_title" "$gh_pr_body" gh_issue_args passthrough
 	fi
 }
 

--- a/templates/gh_issue_develop_agent.tmpl
+++ b/templates/gh_issue_develop_agent.tmpl
@@ -1,0 +1,6 @@
+Implement the following GitHub issue plan. Create a branch, write all necessary
+code changes, and open a pull request.
+
+## ${GH_PR_TITLE}
+
+${GH_PR_BODY}

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -10,12 +10,16 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
+	gum() { :; }
+	gh() { echo ""; }
+	export -f gum gh
+
 	# shellcheck disable=SC2155
 	eval "$(
 		export _gh_ai_source_dir="$REPO_ROOT"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _split_on_separator
+		declare -f _split_on_separator _cmd_assist_remotely
 	)"
 }
 
@@ -100,4 +104,43 @@ setup() {
 
 	[[ ${#before[@]} -eq 0 ]]
 	[[ ${#after[@]} -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _cmd_assist_remotely: CLI dispatch
+# ---------------------------------------------------------------------------
+
+@test "_cmd_assist_remotely: @claude pipes prompt to claude --remote" {
+	claude() { echo "claude $*"; }
+	export -f claude
+
+	local out
+	out=$(_cmd_assist_remotely @claude "owner/repo" "my prompt")
+
+	[[ "$out" == *"--remote"* ]]
+}
+
+@test "_cmd_assist_remotely: @jules calls jules remote new with --repo" {
+	jules() { echo "jules $*"; }
+	export -f jules
+
+	local out
+	out=$(_cmd_assist_remotely @jules "owner/repo" "my prompt")
+
+	[[ "$out" == *"remote new"* ]]
+	[[ "$out" == *"--repo"* ]]
+	[[ "$out" == *"owner/repo"* ]]
+}
+
+@test "_cmd_assist_remotely: @copilot pipes to gh agent-task create with -R" {
+	gh() { echo "gh $*"; }
+	export -f gh
+
+	local out
+	out=$(_cmd_assist_remotely @copilot "owner/repo" "my prompt")
+
+	[[ "$out" == *"agent-task"* ]]
+	[[ "$out" == *"create"* ]]
+	[[ "$out" == *"-R"* ]]
+	[[ "$out" == *"owner/repo"* ]]
 }

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -144,3 +144,9 @@ setup() {
 	[[ "$out" == *"-R"* ]]
 	[[ "$out" == *"owner/repo"* ]]
 }
+
+@test "_cmd_assist_remotely: unknown handle returns error" {
+	run _cmd_assist_remotely @unknown "owner/repo" "my prompt"
+
+	[[ "$status" -eq 1 ]]
+}

--- a/tests/gh_issue_develop.bats
+++ b/tests/gh_issue_develop.bats
@@ -168,7 +168,7 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "_gh_issue_develop_remotely: invokes _cmd_assist_remotely with repo and rendered prompt" {
-	local claude_log="$BATS_TEST_TMPDIR/claude.log"
+	export claude_log="$BATS_TEST_TMPDIR/claude.log"
 	claude() { echo "$*" >"$claude_log"; }
 	gh() { echo "owner/repo"; }
 	gum() {
@@ -376,21 +376,7 @@ _setup_develop_mocks() {
 # _gh_issue_develop: --agent delegation path
 # ---------------------------------------------------------------------------
 
-@test "_gh_issue_develop: --agent @claude invokes claude --remote and returns 0" {
-	local gh_log="$BATS_TEST_TMPDIR/gh.log"
-	local git_log="$BATS_TEST_TMPDIR/git.log"
-	_setup_develop_mocks "$gh_log" "$git_log"
-
-	local claude_log="$BATS_TEST_TMPDIR/claude.log"
-	claude() { echo "$*" >"$claude_log"; }
-	export -f claude
-
-	run _gh_issue_develop 42 --agent @claude
-	[[ "$status" -eq 0 ]]
-	grep -q -- "--remote" "$claude_log"
-}
-
-@test "_gh_issue_develop: --agent path does not call gh issue develop" {
+@test "_gh_issue_develop: --agent @claude succeeds without creating branch or PR" {
 	local gh_log="$BATS_TEST_TMPDIR/gh.log"
 	local git_log="$BATS_TEST_TMPDIR/git.log"
 	_setup_develop_mocks "$gh_log" "$git_log"
@@ -398,10 +384,13 @@ _setup_develop_mocks() {
 	claude() { :; }
 	export -f claude
 
-	_gh_issue_develop 42 --agent @claude
-
+	run _gh_issue_develop 42 --agent @claude
+	[[ "$status" -eq 0 ]]
 	! grep -qx "develop" "$gh_log"
+	! grep -q "commit-tree" "$git_log"
+	! grep -q "pr create" "$gh_log"
 }
+
 
 @test "_gh_issue_develop: --agent path does not create git branch or PR" {
 	local gh_log="$BATS_TEST_TMPDIR/gh.log"

--- a/tests/gh_issue_develop.bats
+++ b/tests/gh_issue_develop.bats
@@ -22,99 +22,128 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_issue.sh"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _parse_issue_develop_args _show_issue_develop_help _gh_issue_develop _get_title _get_body _split_on_separator
+		declare -f _parse_issue_develop_args _show_issue_develop_help _gh_issue_develop \
+			_gh_issue_develop_remotely _gh_issue_develop_no_checkout \
+			_cmd_assist_remotely _get_title _get_body _split_on_separator
 	)"
 }
 
-@test "_parse_issue_develop_args: captures issue number from first positional arg" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42
+# ---------------------------------------------------------------------------
+# _parse_issue_develop_args: issue number
+# ---------------------------------------------------------------------------
+
+@test "_parse_issue_develop_args: sets number from first positional arg" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42
 
 	[[ "$number" == "42" ]]
 	[[ "$checkout" == "false" ]]
 	[[ -z "$base" ]]
 }
 
+# ---------------------------------------------------------------------------
+# _parse_issue_develop_args: branch flags
+# ---------------------------------------------------------------------------
+
 @test "_parse_issue_develop_args: sets base from --base flag" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 --base develop
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --base develop
 
 	[[ "$base" == "develop" ]]
-	[[ -z "$name" ]]
 }
 
 @test "_parse_issue_develop_args: sets base from -b flag" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 -b develop
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 -b develop
 
 	[[ "$base" == "develop" ]]
 }
 
-@test "_parse_issue_develop_args: sets base from --base=value" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 --base=develop
+@test "_parse_issue_develop_args: sets base from --base=value form" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --base=develop
 
 	[[ "$base" == "develop" ]]
 }
 
 @test "_parse_issue_develop_args: sets name from --name flag" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 --name my-branch
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --name my-branch
 
 	[[ "$name" == "my-branch" ]]
 }
 
 @test "_parse_issue_develop_args: sets name from -n flag" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 -n my-branch
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 -n my-branch
 
 	[[ "$name" == "my-branch" ]]
 }
 
 @test "_parse_issue_develop_args: sets branch_repo from --branch-repo flag" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 --branch-repo owner/repo
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --branch-repo owner/repo
 
 	[[ "$branch_repo" == "owner/repo" ]]
 }
 
-@test "_parse_issue_develop_args: enables checkout with --checkout flag" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 --checkout
+# ---------------------------------------------------------------------------
+# _parse_issue_develop_args: checkout flag
+# ---------------------------------------------------------------------------
+
+@test "_parse_issue_develop_args: sets checkout=true from --checkout flag" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --checkout
 
 	[[ "$checkout" == "true" ]]
 }
 
-@test "_parse_issue_develop_args: enables checkout with -c flag" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 -c
+@test "_parse_issue_develop_args: sets checkout=true from -c flag" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 -c
 
 	[[ "$checkout" == "true" ]]
 }
+
+# ---------------------------------------------------------------------------
+# _parse_issue_develop_args: --agent flag
+# ---------------------------------------------------------------------------
+
+@test "_parse_issue_develop_args: sets agent from --agent flag" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --agent @claude
+
+	[[ "$agent" == "@claude" ]]
+}
+
+@test "_parse_issue_develop_args: sets agent from --agent=value form" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --agent=@jules
+
+	[[ "$agent" == "@jules" ]]
+}
+
+@test "_parse_issue_develop_args: sets agent to @copilot" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 --agent=@copilot
+
+	[[ "$agent" == "@copilot" ]]
+}
+
+@test "_parse_issue_develop_args: --agent without value returns error" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	run _parse_issue_develop_args number checkout base name branch_repo agent 42 --agent
+
+	[[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _parse_issue_develop_args: combined flags
+# ---------------------------------------------------------------------------
 
 @test "_parse_issue_develop_args: parses all flags together" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	_parse_issue_develop_args number checkout base name branch_repo 42 -c --base develop --name my-branch
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	_parse_issue_develop_args number checkout base name branch_repo agent 42 -c --base develop --name my-branch
 
 	[[ "$number" == "42" ]]
 	[[ "$checkout" == "true" ]]
@@ -122,26 +151,67 @@ setup() {
 	[[ "$name" == "my-branch" ]]
 }
 
-@test "_parse_issue_develop_args: returns error with hint for unknown flags" {
-	local number=""
-	local checkout=false
-	local base="" name="" branch_repo=""
-	run _parse_issue_develop_args number checkout base name branch_repo 42 --draft
+# ---------------------------------------------------------------------------
+# _parse_issue_develop_args: unknown flag error
+# ---------------------------------------------------------------------------
+
+@test "_parse_issue_develop_args: unknown flag before -- returns error with hint" {
+	local number="" checkout=false base="" name="" branch_repo="" agent=""
+	run _parse_issue_develop_args number checkout base name branch_repo agent 42 --draft
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"use -- to pass flags to gh pr create"* ]]
 }
 
 # ---------------------------------------------------------------------------
-# Helpers shared by _gh_issue_develop integration tests
+# _gh_issue_develop_remotely: agent delegation helper
 # ---------------------------------------------------------------------------
 
-# _setup_develop_mocks sets up gh/git/gum mocks that record calls to temp
-# files (passed as arguments) and return appropriate fake values for the full
-# develop workflow.  Callers should use BATS_TEST_TMPDIR for the log paths so
-# bats cleans them up automatically after each test.
-#
-# Usage: _setup_develop_mocks <gh_log> <git_log>
+@test "_gh_issue_develop_remotely: invokes _cmd_assist_remotely with repo and rendered prompt" {
+	local claude_log="$BATS_TEST_TMPDIR/claude.log"
+	claude() { echo "$*" >"$claude_log"; }
+	gh() { echo "owner/repo"; }
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			shift; "$@"
+			;;
+		log) ;;
+		esac
+	}
+	export -f claude gh gum
+
+	_gh_issue_develop_remotely @claude 42 "Fix the bug" "## Plan"
+
+	grep -q -- "--remote" "$claude_log"
+}
+
+@test "_gh_issue_develop_remotely: passes issue number in spin title" {
+	local gum_log="$BATS_TEST_TMPDIR/gum.log"
+	claude() { :; }
+	gh() { echo "owner/repo"; }
+	gum() {
+		case "$1" in
+		spin)
+			echo "$*" >>"$gum_log"
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			shift; "$@"
+			;;
+		log) ;;
+		esac
+	}
+	export -f claude gh gum
+
+	_gh_issue_develop_remotely @claude 99 "Title" "Body"
+
+	grep -q "99" "$gum_log"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers shared by integration tests
+# ---------------------------------------------------------------------------
+
 _setup_develop_mocks() {
 	local gh_log="$1"
 	local git_log="$2"
@@ -182,7 +252,11 @@ _setup_develop_mocks() {
 	export -f gum
 }
 
-@test "_gh_issue_develop: passes --checkout to gh issue develop when -c given" {
+# ---------------------------------------------------------------------------
+# _gh_issue_develop: checkout path
+# ---------------------------------------------------------------------------
+
+@test "_gh_issue_develop: checkout path calls gh issue develop with --checkout" {
 	local gh_log="$BATS_TEST_TMPDIR/gh.log"
 	local git_log="$BATS_TEST_TMPDIR/git.log"
 	_setup_develop_mocks "$gh_log" "$git_log"
@@ -196,7 +270,7 @@ _setup_develop_mocks() {
 	! grep -q "commit-tree" "$git_log"
 }
 
-@test "_gh_issue_develop: omits --head from gh pr create in checkout mode" {
+@test "_gh_issue_develop: checkout path gh pr create does not include --head" {
 	local gh_log="$BATS_TEST_TMPDIR/gh.log"
 	local git_log="$BATS_TEST_TMPDIR/git.log"
 	_setup_develop_mocks "$gh_log" "$git_log"
@@ -206,52 +280,7 @@ _setup_develop_mocks() {
 	! grep -qx -- "--head" "$gh_log"
 }
 
-@test "_gh_issue_develop: omits --checkout from gh issue develop by default" {
-	local gh_log="$BATS_TEST_TMPDIR/gh.log"
-	local git_log="$BATS_TEST_TMPDIR/git.log"
-	_setup_develop_mocks "$gh_log" "$git_log"
-
-	_gh_issue_develop 42
-
-	grep -qx "develop" "$gh_log"
-	! grep -qx -- "--checkout" "$gh_log"
-}
-
-@test "_gh_issue_develop: uses commit-tree workflow without --checkout" {
-	local gh_log="$BATS_TEST_TMPDIR/gh.log"
-	local git_log="$BATS_TEST_TMPDIR/git.log"
-	_setup_develop_mocks "$gh_log" "$git_log"
-
-	_gh_issue_develop 42
-
-	grep -q "fetch origin 42-test-issue" "$git_log"
-	grep -q "commit-tree" "$git_log"
-	grep -q "push origin def456sha:refs/heads/42-test-issue" "$git_log"
-}
-
-@test "_gh_issue_develop: passes --head to gh pr create without --checkout" {
-	local gh_log="$BATS_TEST_TMPDIR/gh.log"
-	local git_log="$BATS_TEST_TMPDIR/git.log"
-	_setup_develop_mocks "$gh_log" "$git_log"
-
-	_gh_issue_develop 42
-
-	grep -qx -- "--head" "$gh_log"
-	grep -qx "42-test-issue" "$gh_log"
-}
-
-@test "_gh_issue_develop: skips empty commit without --checkout" {
-	local gh_log="$BATS_TEST_TMPDIR/gh.log"
-	local git_log="$BATS_TEST_TMPDIR/git.log"
-	_setup_develop_mocks "$gh_log" "$git_log"
-
-	_gh_issue_develop 42
-
-	! grep -q "commit --allow-empty" "$git_log"
-	! grep -q "push -u origin HEAD" "$git_log"
-}
-
-@test "_gh_issue_develop: forwards --base to gh issue develop in checkout mode" {
+@test "_gh_issue_develop: checkout path forwards --base to gh issue develop" {
 	local gh_log="$BATS_TEST_TMPDIR/gh.log"
 	local git_log="$BATS_TEST_TMPDIR/git.log"
 	_setup_develop_mocks "$gh_log" "$git_log"
@@ -263,12 +292,60 @@ _setup_develop_mocks() {
 	grep -qx "main" "$gh_log"
 }
 
-@test "_gh_issue_develop: fails when gh issue develop returns no branch URL" {
+# ---------------------------------------------------------------------------
+# _gh_issue_develop: no-checkout path
+# ---------------------------------------------------------------------------
+
+@test "_gh_issue_develop: no-checkout path does not call gh issue develop with --checkout" {
 	local gh_log="$BATS_TEST_TMPDIR/gh.log"
 	local git_log="$BATS_TEST_TMPDIR/git.log"
 	_setup_develop_mocks "$gh_log" "$git_log"
 
-	# Override gh to return empty output for the develop subcommand
+	_gh_issue_develop 42
+
+	grep -qx "develop" "$gh_log"
+	! grep -qx -- "--checkout" "$gh_log"
+}
+
+@test "_gh_issue_develop: no-checkout path uses git commit-tree workflow" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	_gh_issue_develop 42
+
+	grep -q "fetch origin 42-test-issue" "$git_log"
+	grep -q "commit-tree" "$git_log"
+	grep -q "push origin def456sha:refs/heads/42-test-issue" "$git_log"
+}
+
+@test "_gh_issue_develop: no-checkout path gh pr create includes --head" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	_gh_issue_develop 42
+
+	grep -qx -- "--head" "$gh_log"
+	grep -qx "42-test-issue" "$gh_log"
+}
+
+@test "_gh_issue_develop: no-checkout path does not call git commit --allow-empty" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	_gh_issue_develop 42
+
+	! grep -q "commit --allow-empty" "$git_log"
+	! grep -q "push -u origin HEAD" "$git_log"
+}
+
+@test "_gh_issue_develop: no-checkout path fails when gh issue develop returns empty" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
 	gh() {
 		printf '%s\n' "$@" >>"$gh_log"
 		case "$1 $2" in
@@ -283,7 +360,7 @@ _setup_develop_mocks() {
 	[[ "$status" -eq 1 ]]
 }
 
-@test "_gh_issue_develop: forwards -- flags to gh pr create" {
+@test "_gh_issue_develop: passthrough flags reach gh pr create" {
 	local gh_log="$BATS_TEST_TMPDIR/gh.log"
 	local git_log="$BATS_TEST_TMPDIR/git.log"
 	_setup_develop_mocks "$gh_log" "$git_log"
@@ -293,4 +370,67 @@ _setup_develop_mocks() {
 	grep -qx -- "--draft" "$gh_log"
 	grep -qx -- "--label" "$gh_log"
 	grep -qx "enhancement" "$gh_log"
+}
+
+# ---------------------------------------------------------------------------
+# _gh_issue_develop: --agent delegation path
+# ---------------------------------------------------------------------------
+
+@test "_gh_issue_develop: --agent @claude invokes claude --remote and returns 0" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	local claude_log="$BATS_TEST_TMPDIR/claude.log"
+	claude() { echo "$*" >"$claude_log"; }
+	export -f claude
+
+	run _gh_issue_develop 42 --agent @claude
+	[[ "$status" -eq 0 ]]
+	grep -q -- "--remote" "$claude_log"
+}
+
+@test "_gh_issue_develop: --agent path does not call gh issue develop" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	claude() { :; }
+	export -f claude
+
+	_gh_issue_develop 42 --agent @claude
+
+	! grep -qx "develop" "$gh_log"
+}
+
+@test "_gh_issue_develop: --agent path does not create git branch or PR" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	jules() { :; }
+	export -f jules
+
+	_gh_issue_develop 42 --agent @jules
+
+	! grep -q "commit-tree" "$git_log"
+	! grep -q "pr create" "$gh_log"
+}
+
+@test "_gh_issue_develop: unknown --agent value returns error" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	run _gh_issue_develop 42 --agent @unknown-bot
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_issue_develop: --agent value without @ prefix returns error" {
+	local gh_log="$BATS_TEST_TMPDIR/gh.log"
+	local git_log="$BATS_TEST_TMPDIR/git.log"
+	_setup_develop_mocks "$gh_log" "$git_log"
+
+	run _gh_issue_develop 42 --agent claude
+	[[ "$status" -eq 1 ]]
 }


### PR DESCRIPTION
Closes #23

## Summary

This PR implements a `--remote` flag for the `gh ai issue develop` command that enables delegation of issue resolution to remote AI agents (Claude Remote, Google Jules, GitHub CLI agent tasks) by formatting the PR body as structured prompt instructions instead of creating local branches and PRs.

## Implementation Plan

- [ ] T001 - Add `--remote` flag to the command parser with support for backend specification (claude, jules, github-tasks)
- [ ] T002 - Create a remote agent abstraction layer with implementations for each supported backend (Claude Remote, Google Jules, GitHub CLI agent tasks)
- [ ] T003 - Implement PR body formatting logic that converts issue context and development requirements into structured prompt instructions for remote agents
- [ ] T004 - Add conditional logic to skip local branch/PR creation when `--remote` flag is provided
- [ ] T005 - Implement remote agent execution flow that sends formatted instructions to the specified backend and handles responses
- [ ] T006 - Add validation and error handling for invalid or unavailable remote agent backends with user-friendly error messages
- [ ] T007 - Update command help text and documentation to describe `--remote` flag usage and supported backends
- [ ] T008 - Add integration tests covering remote agent delegation with mocked backends
- [ ] T009 - Add integration tests verifying `--remote` flag compatibility with existing options (issue number, context flags)
- [ ] T010 - Test error handling for invalid backend specifications and unavailable agents

## Acceptance Criteria

- [ ] `--remote` flag is recognized and appears in `gh ai issue develop --help` output with clear documentation
- [ ] Remote agent backend can be specified via `--remote=claude`, `--remote=jules`, or `--remote=github-tasks`
- [ ] PR body is formatted as clear, structured prompt instructions suitable for remote agent execution
- [ ] When `--remote` is provided, no local branch or PR is created; delegation occurs instead
- [ ] Invalid or unavailable remote agents produce clear error messages guiding user action
- [ ] `--remote` flag works correctly in combination with existing `gh ai issue develop` options
- [ ] All remote agent backends (Claude Remote, Google Jules, GitHub CLI agent tasks) are functional and tested

<!-- markdownlint-disable-file MD013 MD022 MD041 MD047 -->