### PR TITLE
Add `chat` subcommand to issue, pr, and run for interactive Claude Code sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ gh ai pr create [-d <DESCRIPTION>] [-B <BASE>] [-- GH_PR_CREATE_OPTIONS]
 gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_EDIT_OPTIONS]
 gh ai pr review [PR_NUMBER] [-d <DESCRIPTION>] [-- GH_PR_REVIEW_OPTIONS]
 gh ai pr explain [PR_NUMBER] [--comment | --edit]
+gh ai pr chat <PR_NUMBER>
 gh ai issue create -d <DESCRIPTION> [-- GH_ISSUE_CREATE_OPTIONS]
 gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [-- GH_ISSUE_EDIT_OPTIONS]
 gh ai issue plan <ISSUE_NUMBER> [-d <DESCRIPTION>]
+gh ai issue chat <ISSUE_NUMBER>
 gh ai run explain <RUN_ID>
+gh ai run chat <RUN_ID>
 ```
 
 ### Commit
@@ -88,6 +91,13 @@ gh ai pr explain 42 --comment    # post as PR comment
 gh ai pr explain 42 --edit       # replace PR description
 ```
 
+Opens a Claude Code review session for a PR in an isolated worktree.
+Re-running the command resumes the previous session.
+
+```bash
+gh ai pr chat 99
+```
+
 ### Issue
 
 Creates a structured GitHub issue from a brief description.
@@ -117,6 +127,13 @@ gh ai issue plan 42 -d "focus on the auth module"
 gh ai issue plan 42 | pbcopy
 ```
 
+Opens a Claude Code session seeded with an implementation plan in an isolated
+worktree. Re-running the command resumes the previous session.
+
+```bash
+gh ai issue chat 42
+```
+
 Pipe to an AI agent to implement:
 
 ```bash
@@ -141,6 +158,13 @@ Analyzes a GitHub Actions workflow run and explains what happened.
 gh ai run explain 123456 # uses --log-failed for failed runs, --log otherwise
 ```
 
+Opens a Claude Code debug session for a workflow run in an isolated worktree.
+Re-running the command resumes the previous session.
+
+```bash
+gh ai run chat 123456
+```
+
 ## Configuration
 
 Override the AI provider and model via `gh config`.
@@ -150,9 +174,9 @@ Override the AI provider and model via `gh config`.
 | `gh-ai.provider`     | `anthropic` | AI provider (`anthropic`)                          |
 | `gh-ai.model`        | `haiku`     | Model for all commands (fallback)                  |
 | `gh-ai.commit.model` |             | Model override for `commit`                        |
-| `gh-ai.pr.model`     |             | Model override for `pr create/edit/review/explain` |
-| `gh-ai.issue.model`  |             | Model override for `issue create/edit/plan`        |
-| `gh-ai.run.model`    |             | Model override for `run explain`                   |
+| `gh-ai.pr.model`     |             | Model override for `pr` subcommands                |
+| `gh-ai.issue.model`  |             | Model override for `issue` subcommands             |
+| `gh-ai.run.model`    |             | Model override for `run` subcommands               |
 
 Per-command keys take priority over `gh-ai.model`.
 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ gh config set gh-ai.pr.model sonnet
 
 [gh-fzf](https://github.com/gh-extensions/gh-fzf) is a GitHub CLI extension
 that wraps `gh` commands in an interactive fuzzy finder. Source
-`extras/gh_fzf_ai.sh` in your shell config to register `gh-ai` keybinds via
+`extras/gh_fzf.sh` in your shell config to register `gh-ai` keybinds via
 `GH_FZF_*_OPTS`.
 
 ```bash
-source "$HOME/.local/share/gh/extensions/gh-ai/extras/gh_fzf_ai.sh"
+source "$HOME/.local/share/gh/extensions/gh-ai/extras/gh_fzf.sh"
 ```
 
 | Context             | Key     | Action                                           |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ explain CI failures.
 - [Bash](https://www.gnu.org/software/bash/) 4.4+ (`bash`) — macOS: `brew install bash`
 - [GitHub CLI](https://cli.github.com/) (`gh`) — macOS: `brew install gh`
 - [Claude Code](https://docs.anthropic.com/en/docs/build-with-claude/claude-code) (`claude`)
+- [OSSP uuid](http://www.ossp.org/pkg/lib/uuid/) (`uuid`) — macOS: `brew install ossp-uuid`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -208,10 +208,13 @@ source "$HOME/.local/share/gh/extensions/gh-ai/extras/gh_fzf_ai.sh"
 | Context             | Key     | Action                                           |
 | ------------------- | ------- | ------------------------------------------------ |
 | `gh-fzf issue`      | `alt-P` | Generate AI plan for the selected issue          |
+| `gh-fzf issue`      | `alt-D` | Open a Claude Code chat session (tmux only)      |
 | `gh-fzf pr`         | `alt-E` | Explain the selected PR                          |
 | `gh-fzf pr`         | `alt-A` | Approve the selected PR via AI review            |
 | `gh-fzf pr`         | `alt-N` | Request changes on the selected PR via AI review |
+| `gh-fzf pr`         | `alt-R` | Open a Claude Code review session (tmux only)    |
 | `gh-fzf run`        | `alt-E` | Explain the selected workflow run failure        |
+| `gh-fzf run`        | `alt-D` | Open a Claude Code debug session (tmux only)     |
 | `gh-fzf search prs` | `alt-E` | Explain the selected PR                          |
 | `gh-fzf search prs` | `alt-A` | Approve the selected PR via AI review            |
 | `gh-fzf search prs` | `alt-N` | Request changes on the selected PR via AI review |

--- a/README.md
+++ b/README.md
@@ -216,9 +216,6 @@ source "$HOME/.local/share/gh/extensions/gh-ai/extras/gh_fzf.sh"
 | `gh-fzf pr`         | `alt-R` | Open a Claude Code review session (tmux only)    |
 | `gh-fzf run`        | `alt-E` | Explain the selected workflow run failure        |
 | `gh-fzf run`        | `alt-D` | Open a Claude Code debug session (tmux only)     |
-| `gh-fzf search prs` | `alt-E` | Explain the selected PR                          |
-| `gh-fzf search prs` | `alt-A` | Approve the selected PR via AI review            |
-| `gh-fzf search prs` | `alt-N` | Request changes on the selected PR via AI review |
 
 ## License
 

--- a/extras/gh_fzf.sh
+++ b/extras/gh_fzf.sh
@@ -20,10 +20,6 @@
 #     alt-E   Explain the selected workflow run failure with AI
 #     alt-D   Open a Claude Code debug session for the run (tmux only)
 #
-#   gh-fzf search prs
-#     alt-E   Explain the selected PR with AI
-#     alt-A   Approve the selected PR via AI review
-#     alt-N   Request changes on the selected PR via AI review
 
 _gh_fzf_issue_opts=(
 	'--bind "alt-P:execute(gh ai issue plan {1} | gum format | gum pager)"'
@@ -59,11 +55,3 @@ if [[ -n "${TMUX:-}" ]]; then
 fi
 export GH_FZF_RUN_OPTS="${GH_FZF_RUN_OPTS:+${GH_FZF_RUN_OPTS} }${_gh_fzf_run_opts[*]}"
 unset _gh_fzf_run_opts
-
-_gh_fzf_search_pr_opts=(
-	'--bind "alt-E:execute(gh ai pr explain {1} --repo {2} | gum pager)"'
-	'--bind "alt-A:execute(gh ai pr review {1} --repo {2} -- --approve)"'
-	'--bind "alt-N:execute(gh ai pr review {1} --repo {2} -- --request-changes)"'
-)
-export GH_FZF_SEARCH_PR_OPTS="${GH_FZF_SEARCH_PR_OPTS:+${GH_FZF_SEARCH_PR_OPTS} }${_gh_fzf_search_pr_opts[*]}"
-unset _gh_fzf_search_pr_opts

--- a/extras/gh_fzf.sh
+++ b/extras/gh_fzf.sh
@@ -2,7 +2,7 @@
 # gh-ai keybinds with gh-fzf via GH_FZF_*_OPTS.
 #
 # Usage: add to ~/.bashrc or ~/.zshrc
-#   source /path/to/extras/gh_fzf_ai.sh
+#   source /path/to/extras/gh_fzf.sh
 #
 # Keybinds added:
 #

--- a/extras/gh_fzf_ai.sh
+++ b/extras/gh_fzf_ai.sh
@@ -8,14 +8,17 @@
 #
 #   gh-fzf issue
 #     alt-P   Generate and view AI plan for the selected issue
+#     alt-D   Open a Claude Code chat session for the issue (tmux only)
 #
 #   gh-fzf pr
 #     alt-E   Explain the selected PR with AI
 #     alt-A   Approve the selected PR via AI review
 #     alt-N   Request changes on the selected PR via AI review
+#     alt-R   Open a Claude Code review session for the PR (tmux only)
 #
 #   gh-fzf run
 #     alt-E   Explain the selected workflow run failure with AI
+#     alt-D   Open a Claude Code debug session for the run (tmux only)
 #
 #   gh-fzf search prs
 #     alt-E   Explain the selected PR with AI
@@ -25,6 +28,11 @@
 _gh_fzf_issue_opts=(
 	'--bind "alt-P:execute(gh ai issue plan {1} | gum format | gum pager)"'
 )
+if [[ -n "${TMUX:-}" ]]; then
+	_gh_fzf_issue_opts+=(
+		'--bind "alt-D:execute(tmux new-window -n I{1} gh ai issue chat {1})"'
+	)
+fi
 export GH_FZF_ISSUE_OPTS="${GH_FZF_ISSUE_OPTS:+${GH_FZF_ISSUE_OPTS} }${_gh_fzf_issue_opts[*]}"
 unset _gh_fzf_issue_opts
 
@@ -33,12 +41,22 @@ _gh_fzf_pr_opts=(
 	'--bind "alt-A:execute(gh ai pr review {1} -- --approve)"'
 	'--bind "alt-N:execute(gh ai pr review {1} -- --request-changes)"'
 )
+if [[ -n "${TMUX:-}" ]]; then
+	_gh_fzf_pr_opts+=(
+		'--bind "alt-R:execute(tmux new-window -n P{1} gh ai pr chat {1})"'
+	)
+fi
 export GH_FZF_PR_OPTS="${GH_FZF_PR_OPTS:+${GH_FZF_PR_OPTS} }${_gh_fzf_pr_opts[*]}"
 unset _gh_fzf_pr_opts
 
 _gh_fzf_run_opts=(
 	'--bind "alt-E:execute(gh ai run explain {-1} | gum format | gum pager)"'
 )
+if [[ -n "${TMUX:-}" ]]; then
+	_gh_fzf_run_opts+=(
+		'--bind "alt-D:execute(tmux new-window -n R{-1} gh ai run chat {-1})"'
+	)
+fi
 export GH_FZF_RUN_OPTS="${GH_FZF_RUN_OPTS:+${GH_FZF_RUN_OPTS} }${_gh_fzf_run_opts[*]}"
 unset _gh_fzf_run_opts
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
             gum
             bats
             shellcheck
-            ossp-uuid
+            libossp_uuid
           ];
 
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
             gum
             bats
             shellcheck
+            ossp-uuid
           ];
 
           shellHook = ''

--- a/gh-ai
+++ b/gh-ai
@@ -61,10 +61,10 @@ USAGE:
     gh ai <command> [subcommand] [options]
 
 COMMANDS:
-    pr          Pull request operations (create, edit, review, explain)
+    pr          Pull request operations (create, edit, review, explain, chat)
     commit      Generate a commit message for staged changes
-    issue       Issue operations (create, edit, plan)
-    run         Workflow run operations (explain)
+    issue       Issue operations (create, edit, plan, chat)
+    run         Workflow run operations (explain, chat)
 
 SEE ALSO:
     gh ai pr --help        # PR command help

--- a/gh-ai
+++ b/gh-ai
@@ -8,7 +8,7 @@ _gh_ai_source_dir=$(dirname "${BASH_SOURCE[0]}")
 
 # Verify required dependencies are installed
 #
-# Checks that Bash 4.4+, gh, claude, and gum are available.
+# Checks that Bash 4.4+, gh, claude, gum, and uuid are available.
 # Prints installation instructions and exits if any are missing.
 _check_dependencies() {
 	if [[ "${BASH_VERSINFO[0]}" -lt 4 || ("${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -lt 4) ]]; then
@@ -27,6 +27,9 @@ _check_dependencies() {
 	fi
 	if ! command -v gum &>/dev/null; then
 		missing+=("gum     — https://github.com/charmbracelet/gum")
+	fi
+	if ! command -v uuid &>/dev/null; then
+		missing+=("uuid    — macOS: brew install ossp-uuid")
 	fi
 	if [[ ${#missing[@]} -gt 0 ]]; then
 		echo "gh-ai: missing required dependencies:" >&2

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -255,7 +255,7 @@ _git_worktree_sync() {
 	if [[ ! -d "$worktree_path" ]]; then
 		gum spin --title "Fetching $label branch..." -- \
 			git fetch origin "$remote_branch" || true
-		git worktree add -B "$branch" "$worktree_path" "origin/$remote_branch"
+		git worktree add -B "$branch" "$worktree_path" "origin/$remote_branch" >/dev/null
 	else
 		gum spin --title "Updating $label worktree..." -- \
 			git -C "$worktree_path" merge --ff-only "origin/$remote_branch" 2>/dev/null || {

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -108,7 +108,8 @@ _cmd_chat() {
 		if [[ -f "$session_file" ]]; then
 			claude "${claude_args[@]}" --resume "$session_id"
 		else
-			preamble="$(printf '%s\n\n' "$preamble")"
+			printf -v preamble '%s\n' "$preamble"
+			# start the agent
 			"$@" | claude "${claude_args[@]}" --session-id "$session_id" "$preamble" && touch "$session_file"
 		fi
 		;;

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -250,32 +250,49 @@ _init_claude_session() {
 
 # Create or fast-forward a worktree for a given branch
 #
-# If the worktree path does not exist, creates it with `git worktree add -B`.
-# If it already exists, fast-forward merges from the remote branch.
-# Returns 1 (with an error message) if the merge would not be fast-forward.
+# If the worktree path does not exist, fetches and creates it with
+# `git worktree add -B`. If it already exists, fast-forward merges
+# from the remote branch. Returns 1 if the merge would not be fast-forward.
 #
-# Usage: _git_worktree_sync <branch> <path> <remote_branch> <label>
+# Usage: _git_worktree_sync <branch> <path> <remote_branch>
 #   branch         — local branch name (e.g. "pr-99")
 #   path           — absolute worktree path
 #   remote_branch  — remote branch to fetch/merge (e.g. "feature/my-change")
-#   label          — human-readable label for spinner messages
 _git_worktree_sync() {
 	local git_branch="$1"
 	local git_worktree_path="$2"
 	local git_remote_branch="$3"
-	local label="$4"
 
 	if [[ ! -d "$git_worktree_path" ]]; then
-		gum spin --title "Fetching $label branch..." -- \
-			git fetch origin "$git_remote_branch" || true
+		git fetch origin "$git_remote_branch" || true
 		git worktree add -B "$git_branch" "$git_worktree_path" "origin/$git_remote_branch" >/dev/null
 	else
-		gum spin --title "Updating $label worktree..." -- \
-			git -C "$git_worktree_path" merge --ff-only "origin/$git_remote_branch" 2>/dev/null || {
+		git -C "$git_worktree_path" merge --ff-only "origin/$git_remote_branch" 2>/dev/null || {
 			gum log --level error "Worktree '$git_worktree_path' has diverged from origin/$git_remote_branch — resolve manually"
 			return 1
 		}
 	fi
+}
+
+# Create a worktree for an issue branch (best-effort)
+#
+# Tries to fetch the branch from origin; if it doesn't exist, uses
+# `gh issue develop` to create it. Then creates the worktree, falling back
+# to a fresh local branch if the remote branch is unavailable.
+#
+# Usage: _git_worktree_create <branch> <path> <issue_number>
+#   branch         — local branch name (e.g. "issue-42")
+#   path           — absolute worktree path
+#   issue_number   — GitHub issue number (for gh issue develop)
+_git_worktree_create() {
+	local git_branch="$1"
+	local git_worktree_path="$2"
+	local gh_issue_number="$3"
+
+	git fetch origin "$git_branch" >/dev/null 2>&1 ||
+		gh issue develop "$gh_issue_number" --name "$git_branch" >/dev/null 2>&1 || true
+	git worktree add -B "$git_branch" "$git_worktree_path" "origin/$git_branch" >/dev/null 2>&1 ||
+		git worktree add -b "$git_branch" "$git_worktree_path" >/dev/null 2>&1 || true
 }
 
 main() {
@@ -289,8 +306,16 @@ main() {
 	assist)
 		_cmd_assist "${2:-}"
 		;;
+	worktree-sync)
+		shift
+		_git_worktree_sync "$@"
+		;;
+	worktree-create)
+		shift
+		_git_worktree_create "$@"
+		;;
 	*)
-		gum log --level error "Usage: gh_cmd.sh <render|assist> [args]"
+		gum log --level error "Usage: gh_cmd.sh <render|assist|worktree-sync|worktree-create> [args]"
 		exit 1
 		;;
 	esac

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -81,18 +81,18 @@ _cmd_assist() {
 # session with that output as the initial prompt, and touches the sentinel
 # file on success.
 #
-# Usage: _cmd_chat <session_file> <worktree_name> <session_id> <system_prompt> <model> [cmd...]
+# Usage: _cmd_chat <session_file> <worktree_name> <session_id> <preamble> <model> [cmd...]
 #   session_file   — path to the sentinel file (created on first run)
 #   worktree_name  — worktree name passed to claude --worktree (e.g. "issue-42")
 #   session_id     — deterministic UUID for --session-id / --resume
-#   system_prompt  — appended system prompt (pass "" to omit)
+#   preamble       — instruction prepended to the initial prompt (required)
 #   model          — optional model string (pass "" to let claude use its default)
 #   cmd...         — command whose stdout seeds the initial prompt
 _cmd_chat() {
 	local session_file="$1"
 	local worktree_name="$2"
 	local session_id="$3"
-	local system_prompt="$4"
+	local preamble="$4"
 	local agent_model="$5"
 	shift 5
 
@@ -104,12 +104,11 @@ _cmd_chat() {
 	anthropic)
 		local claude_args=(--worktree "$worktree_name")
 		[[ -n "$agent_model" ]] && claude_args+=(--model "$agent_model")
-		[[ -n "$system_prompt" ]] && claude_args+=(--append-system-prompt "$system_prompt")
 
 		if [[ -f "$session_file" ]]; then
 			claude "${claude_args[@]}" --resume "$session_id"
 		else
-			"$@" | claude "${claude_args[@]}" --session-id "$session_id" && touch "$session_file"
+			"$@" | claude "${claude_args[@]}" --session-id "$session_id" "$preamble" && touch "$session_file"
 		fi
 		;;
 	*)

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -67,7 +67,53 @@ _cmd_assist() {
 		;;
 	*)
 		gum log --level error "Unsupported provider '$agent_provider' (supported: anthropic)"
-		exit 1
+		return 1
+		;;
+	esac
+}
+
+# Launch or resume a Claude Code chat session in a worktree
+#
+# Reads the gh-ai provider from gh config (defaults to anthropic).
+# Returns 1 with an error if the provider is not supported.
+# If the session sentinel file exists, resumes the previous session.
+# Otherwise pipes cmd... into claude to start a new session, then touches
+# the sentinel file on success.
+#
+# Usage: _cmd_chat <session_file> <worktree_path> <session_id> <system_prompt> <model> [cmd...]
+#   session_file   — path to the sentinel file (created on first run)
+#   worktree_path  — path to the git worktree to open claude in
+#   session_id     — deterministic UUID for --session-id / --resume
+#   system_prompt  — appended system prompt (pass "" to omit)
+#   model          — optional model string (pass "" to let claude use its default)
+#   cmd...         — command whose stdout seeds the initial prompt
+_cmd_chat() {
+	local session_file="$1"
+	local worktree_path="$2"
+	local session_id="$3"
+	local system_prompt="$4"
+	local agent_model="$5"
+	shift 5
+
+	local agent_provider
+	agent_provider=$(gh config get gh-ai.provider 2>/dev/null || true)
+	agent_provider="${agent_provider:-anthropic}"
+
+	case "$agent_provider" in
+	anthropic)
+		local claude_args=(--worktree "$worktree_path")
+		[[ -n "$agent_model" ]] && claude_args+=(--model "$agent_model")
+		[[ -n "$system_prompt" ]] && claude_args+=(--append-system-prompt "$system_prompt")
+
+		if [[ -f "$session_file" ]]; then
+			claude "${claude_args[@]}" --resume "$session_id"
+		else
+			"$@" | claude "${claude_args[@]}" --session-id "$session_id" && touch "$session_file"
+		fi
+		;;
+	*)
+		gum log --level error "Unsupported provider '$agent_provider' (supported: anthropic)"
+		return 1
 		;;
 	esac
 }
@@ -136,6 +182,87 @@ _split_on_separator() {
 		_before_ref+=("$1")
 		shift
 	done
+}
+
+# Resolve the current repo's nameWithOwner (e.g. "owner/repo")
+#
+# Writes the result into the nameref; returns 1 and logs an error on failure.
+#
+# Usage: _get_repo_name repo_ref
+_get_repo_name() {
+	local -n _repo_ref="$1"
+	_repo_ref=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
+	if [[ -z "$_repo_ref" ]]; then
+		gum log --level error "Not inside a GitHub repository (gh repo view failed)"
+		return 1
+	fi
+}
+
+# Resolve the git repository root directory
+#
+# Writes the result into the nameref; returns 1 and logs an error on failure.
+#
+# Usage: _get_git_repo_path git_dir_ref
+_get_git_repo_path() {
+	local -n _git_dir_ref="$1"
+	_git_dir_ref=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	if [[ -z "$_git_dir_ref" ]]; then
+		gum log --level error "Not inside a git repository"
+		return 1
+	fi
+}
+
+# Initialise a deterministic chat session
+#
+# Derives a UUID v5 session ID from the repo name and entity key, writes the
+# ID and the sentinel file path into the provided namerefs, and creates the
+# session directory.
+#
+# Usage: _init_claude_session id_ref file_ref <repo_name> <entity_key> <git_dir>
+#   repo_name   — "owner/repo" string
+#   entity_key  — e.g. "I42", "P99", "R12345"
+#   git_dir     — absolute path returned by git rev-parse --show-toplevel
+_init_claude_session() {
+	local -n _id_ref="$1"
+	local -n _file_ref="$2"
+	local repo_name="$3"
+	local entity_key="$4"
+	local git_dir="$5"
+
+	_id_ref=$(uuid -v5 ns:URL "${repo_name}#${entity_key}")
+	local session_dir="$git_dir/.claude/sessions"
+	mkdir -p "$session_dir"
+	_file_ref="$session_dir/$_id_ref"
+}
+
+# Create or fast-forward a worktree for a given branch
+#
+# If the worktree path does not exist, creates it with `git worktree add -B`.
+# If it already exists, fast-forward merges from the remote branch.
+# Returns 1 (with an error message) if the merge would not be fast-forward.
+#
+# Usage: _git_worktree_sync <branch> <path> <remote_branch> <label>
+#   branch         — local branch name (e.g. "pr-99")
+#   path           — absolute worktree path
+#   remote_branch  — remote branch to fetch/merge (e.g. "feature/my-change")
+#   label          — human-readable label for spinner messages
+_git_worktree_sync() {
+	local branch="$1"
+	local wt_path="$2"
+	local remote_branch="$3"
+	local label="$4"
+
+	if [[ ! -d "$wt_path" ]]; then
+		gum spin --title "Fetching $label branch..." -- \
+			git fetch origin "$remote_branch" || true
+		git worktree add -B "$branch" "$wt_path" "origin/$remote_branch"
+	else
+		gum spin --title "Updating $label worktree..." -- \
+			git -C "$wt_path" merge --ff-only "origin/$remote_branch" 2>/dev/null || {
+			gum log --level error "Worktree '$wt_path' has diverged from origin/$remote_branch — resolve manually"
+			return 1
+		}
+	fi
 }
 
 main() {

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -128,11 +128,11 @@ _cmd_chat() {
 # Example: _get_title "# Fix bug in parser\n\nDescription..."
 # Returns: "Fix bug in parser"
 _get_title() {
-	local ai_content="$1"
+	local content="$1"
 
 	local title
 	# Extract title (first line with # prefix removed)
-	title=$(printf '%s\n' "$ai_content" | head -n 1 | sed 's/^# *//')
+	title=$(printf '%s\n' "$content" | head -n 1 | sed 's/^# *//')
 
 	# Validate we got a title
 	if [[ -z "$title" ]]; then
@@ -147,11 +147,11 @@ _get_title() {
 # Takes everything after the first line of AI content (skipping the title),
 # removes leading blank lines, and prepends a markdownlint directive.
 _get_body() {
-	local ai_content="$1"
+	local content="$1"
 
 	local body
 	# Extract body (skip first line) and remove leading blank lines
-	body=$(printf '%s\n' "$ai_content" | tail -n +2 | sed '/./,$!d')
+	body=$(printf '%s\n' "$content" | tail -n +2 | sed '/./,$!d')
 
 	# Suppress common markdownlint warnings in AI-generated body
 	local footer
@@ -192,9 +192,9 @@ _split_on_separator() {
 #
 # Usage: _get_repo_name repo_ref
 _get_repo_name() {
-	local -n _repo_ref="$1"
-	_repo_ref=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
-	if [[ -z "$_repo_ref" ]]; then
+	local -n _gh_repo_ref="$1"
+	_gh_repo_ref=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
+	if [[ -z "$_gh_repo_ref" ]]; then
 		gum log --level error "Not inside a GitHub repository (gh repo view failed)"
 		return 1
 	fi
@@ -227,12 +227,12 @@ _get_git_repo_path() {
 _init_claude_session() {
 	local -n _id_ref="$1"
 	local -n _file_ref="$2"
-	local repo_name="$3"
-	local entity_key="$4"
-	local git_dir="$5"
+	local git_repo_name="$3"
+	local gh_entity_key="$4"
+	local git_repo_path="$5"
 
-	_id_ref=$(uuid -v5 ns:URL "${repo_name}#${entity_key}")
-	local session_dir="$git_dir/.claude/sessions"
+	_id_ref=$(uuid -v5 ns:URL "${git_repo_name}#${gh_entity_key}")
+	local session_dir="$git_repo_path/.claude/sessions"
 	mkdir -p "$session_dir"
 	_file_ref="$session_dir/$_id_ref"
 }
@@ -249,19 +249,19 @@ _init_claude_session() {
 #   remote_branch  — remote branch to fetch/merge (e.g. "feature/my-change")
 #   label          — human-readable label for spinner messages
 _git_worktree_sync() {
-	local branch="$1"
-	local worktree_path="$2"
-	local remote_branch="$3"
+	local git_branch="$1"
+	local git_worktree_path="$2"
+	local git_remote_branch="$3"
 	local label="$4"
 
-	if [[ ! -d "$worktree_path" ]]; then
+	if [[ ! -d "$git_worktree_path" ]]; then
 		gum spin --title "Fetching $label branch..." -- \
-			git fetch origin "$remote_branch" || true
-		git worktree add -B "$branch" "$worktree_path" "origin/$remote_branch" >/dev/null
+			git fetch origin "$git_remote_branch" || true
+		git worktree add -B "$git_branch" "$git_worktree_path" "origin/$git_remote_branch" >/dev/null
 	else
 		gum spin --title "Updating $label worktree..." -- \
-			git -C "$worktree_path" merge --ff-only "origin/$remote_branch" 2>/dev/null || {
-			gum log --level error "Worktree '$worktree_path' has diverged from origin/$remote_branch — resolve manually"
+			git -C "$git_worktree_path" merge --ff-only "origin/$git_remote_branch" 2>/dev/null || {
+			gum log --level error "Worktree '$git_worktree_path' has diverged from origin/$git_remote_branch — resolve manually"
 			return 1
 		}
 	fi

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -223,11 +223,11 @@ _get_git_repo_path() {
 # The entity_key prefix (I = issue, P = PR, R = run) disambiguates entities
 # that share the same number within the UUID v5 namespace.
 #
-# Usage: _init_claude_session id_ref file_ref <repo_name> <entity_key> <git_dir>
+# Usage: _init_chat_session id_ref file_ref <repo_name> <entity_key> <git_dir>
 #   repo_name   — "owner/repo" string
 #   entity_key  — e.g. "I42", "P99", "R12345" (prefix + number)
 #   git_dir     — absolute path returned by git rev-parse --show-toplevel
-_init_claude_session() {
+_init_chat_session() {
 	local -n _id_ref="$1"
 	local -n _file_ref="$2"
 	local git_repo_name="$3"

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -77,19 +77,20 @@ _cmd_assist() {
 # Reads the gh-ai provider from gh config (defaults to anthropic).
 # Returns 1 with an error if the provider is not supported.
 # If the session sentinel file exists, resumes the previous session.
-# Otherwise pipes cmd... into claude to start a new session, then touches
-# the sentinel file on success.
+# Otherwise runs cmd... to capture its output, then starts a new claude
+# session with that output as the initial prompt, and touches the sentinel
+# file on success.
 #
-# Usage: _cmd_chat <session_file> <worktree_path> <session_id> <system_prompt> <model> [cmd...]
+# Usage: _cmd_chat <session_file> <worktree_name> <session_id> <system_prompt> <model> [cmd...]
 #   session_file   — path to the sentinel file (created on first run)
-#   worktree_path  — path to the git worktree to open claude in
+#   worktree_name  — worktree name passed to claude --worktree (e.g. "issue-42")
 #   session_id     — deterministic UUID for --session-id / --resume
 #   system_prompt  — appended system prompt (pass "" to omit)
 #   model          — optional model string (pass "" to let claude use its default)
 #   cmd...         — command whose stdout seeds the initial prompt
 _cmd_chat() {
 	local session_file="$1"
-	local worktree_path="$2"
+	local worktree_name="$2"
 	local session_id="$3"
 	local system_prompt="$4"
 	local agent_model="$5"
@@ -101,7 +102,7 @@ _cmd_chat() {
 
 	case "$agent_provider" in
 	anthropic)
-		local claude_args=(--worktree "$worktree_path")
+		local claude_args=(--worktree "$worktree_name")
 		[[ -n "$agent_model" ]] && claude_args+=(--model "$agent_model")
 		[[ -n "$system_prompt" ]] && claude_args+=(--append-system-prompt "$system_prompt")
 

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -248,18 +248,18 @@ _init_claude_session() {
 #   label          — human-readable label for spinner messages
 _git_worktree_sync() {
 	local branch="$1"
-	local wt_path="$2"
+	local worktree_path="$2"
 	local remote_branch="$3"
 	local label="$4"
 
-	if [[ ! -d "$wt_path" ]]; then
+	if [[ ! -d "$worktree_path" ]]; then
 		gum spin --title "Fetching $label branch..." -- \
 			git fetch origin "$remote_branch" || true
-		git worktree add -B "$branch" "$wt_path" "origin/$remote_branch"
+		git worktree add -B "$branch" "$worktree_path" "origin/$remote_branch"
 	else
 		gum spin --title "Updating $label worktree..." -- \
-			git -C "$wt_path" merge --ff-only "origin/$remote_branch" 2>/dev/null || {
-			gum log --level error "Worktree '$wt_path' has diverged from origin/$remote_branch — resolve manually"
+			git -C "$worktree_path" merge --ff-only "origin/$remote_branch" 2>/dev/null || {
+			gum log --level error "Worktree '$worktree_path' has diverged from origin/$remote_branch — resolve manually"
 			return 1
 		}
 	fi

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -108,6 +108,7 @@ _cmd_chat() {
 		if [[ -f "$session_file" ]]; then
 			claude "${claude_args[@]}" --resume "$session_id"
 		else
+			preamble="$(printf '%s\n\n' "$preamble")"
 			"$@" | claude "${claude_args[@]}" --session-id "$session_id" "$preamble" && touch "$session_file"
 		fi
 		;;

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -220,9 +220,12 @@ _get_git_repo_path() {
 # ID and the sentinel file path into the provided namerefs, and creates the
 # session directory.
 #
+# The entity_key prefix (I = issue, P = PR, R = run) disambiguates entities
+# that share the same number within the UUID v5 namespace.
+#
 # Usage: _init_claude_session id_ref file_ref <repo_name> <entity_key> <git_dir>
 #   repo_name   — "owner/repo" string
-#   entity_key  — e.g. "I42", "P99", "R12345"
+#   entity_key  — e.g. "I42", "P99", "R12345" (prefix + number)
 #   git_dir     — absolute path returned by git rev-parse --show-toplevel
 _init_claude_session() {
 	local -n _id_ref="$1"
@@ -232,8 +235,16 @@ _init_claude_session() {
 	local git_repo_path="$5"
 
 	_id_ref=$(uuid -v5 ns:URL "${git_repo_name}#${gh_entity_key}")
+	if [[ -z "$_id_ref" ]]; then
+		gum log --level error "Failed to generate session ID (uuid returned empty)"
+		return 1
+	fi
+
 	local session_dir="$git_repo_path/.claude/sessions"
-	mkdir -p "$session_dir"
+	if ! mkdir -p "$session_dir"; then
+		gum log --level error "Failed to create session directory: $session_dir"
+		return 1
+	fi
 	_file_ref="$session_dir/$_id_ref"
 }
 

--- a/scripts/gh_commit.sh
+++ b/scripts/gh_commit.sh
@@ -57,7 +57,7 @@ _parse_commit_args() {
 		case "${raw_args[$i]}" in
 		--description | -d)
 			if (( i + 1 >= ${#raw_args[@]} )); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
 			gh_commit_description_ref="${raw_args[$((i + 1))]}"
@@ -67,11 +67,11 @@ _parse_commit_args() {
 			gh_commit_description_ref="${raw_args[$i]#--description=}"
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}' (use -- to pass flags to git commit)" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to git commit)"
 			return 1
 			;;
 		*)
-			echo "error: unexpected argument '${raw_args[$i]}'" >&2
+			gum log --level error "unexpected argument '${raw_args[$i]}'"
 			return 1
 			;;
 		esac

--- a/scripts/gh_commit.sh
+++ b/scripts/gh_commit.sh
@@ -19,7 +19,7 @@ DESCRIPTION:
     Generates a conventional commit message from staged changes using AI,
     then creates the commit. Options after -- are passed to git commit.
 
-OPTIONS:
+FLAGS:
     -d, --description <TEXT>    Additional context for AI commit message generation
 
 EXAMPLES:
@@ -64,6 +64,7 @@ _parse_commit_args() {
 			skip_next=true
 			;;
 		--description=*)
+			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_commit_description_ref="${raw_args[$i]#--description=}"
 			;;
 		-*)

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -537,7 +537,7 @@ _gh_issue_chat() {
 
 	# Create worktree only if it does not exist; do not auto-merge dev branches
 	if [[ ! -d "$wt_path" ]]; then
-		gum spin --title "Setting up worktree for issue #$gh_issue_number..." -- \
+		gum spin --title "Setting up Git worktree for GitHub issue #$gh_issue_number..." -- \
 			bash -c "git fetch origin '$branch' >/dev/null 2>&1 ||
 				gh issue develop '$gh_issue_number' --name '$branch' >/dev/null 2>&1 || true;
 				git worktree add -B '$branch' '$wt_path' 'origin/$branch' >/dev/null 2>&1 ||

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -523,7 +523,7 @@ _gh_issue_chat() {
 	_get_git_repo_path git_dir || return 1
 
 	local session_id session_file
-	_init_claude_session session_id session_file "$repo_name" "I${gh_issue_number}" "$git_dir"
+	_init_chat_session session_id session_file "$repo_name" "I${gh_issue_number}" "$git_dir"
 
 	local git_branch="issue-${gh_issue_number}"
 	# shellcheck disable=SC2154

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -504,7 +504,7 @@ _parse_issue_chat_args() {
 # branch issue-N (or reuses an existing one), and opens a Claude Code session
 # seeded with the plan. Re-running resumes the previous session.
 #
-# Usage: _gh_issue_chat <ISSUE_NUMBER>
+# Usage: _gh_issue_chat <NUMBER>
 _gh_issue_chat() {
 	case "${1:-}" in
 	--help | -h | help)

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -257,12 +257,6 @@ _gh_issue_edit() {
 	# Parse body from output
 	gh_issue_new_body=$(_get_body "$output")
 
-	# Validate we got body content
-	if [[ -z "$gh_issue_new_body" ]]; then
-		gum log --level error "Failed to extract body from AI content"
-		return 1
-	fi
-
 	# Edit issue with AI-generated content
 	gh issue edit "$gh_issue_number" --title "$gh_issue_new_title" --body "$gh_issue_new_body" "${passthrough[@]}"
 }
@@ -638,12 +632,6 @@ _gh_issue_create() {
 	# Parse body from output
 	gh_issue_body=$(_get_body "$output")
 
-	# Validate we got body content
-	if [[ -z "$gh_issue_body" ]]; then
-		gum log --level error "Failed to extract body from AI content"
-		return 1
-	fi
-
 	# Create issue with AI-generated content
 	gh issue create --title "$gh_issue_title" --body "$gh_issue_body" "${passthrough[@]}"
 }
@@ -679,7 +667,7 @@ _gh_issue() {
 		gum log --level error "Unknown issue command '$subcommand'"
 		gum log --level info "Available commands: create, edit, plan, chat"
 		gum log --level info "Run 'gh ai issue --help' for usage information"
-		exit 1
+		return 1
 		;;
 	esac
 }

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -538,15 +538,24 @@ _gh_issue_chat() {
 	# Create worktree only if it does not exist; do not auto-merge dev branches
 	if [[ ! -d "$wt_path" ]]; then
 		gum spin --title "Setting up worktree for issue #$gh_issue_number..." -- \
-			git fetch origin "$branch" 2>/dev/null ||
-			gh issue develop "$gh_issue_number" --name "$branch" 2>/dev/null || true
-		git worktree add -B "$branch" "$wt_path" "origin/$branch" 2>/dev/null ||
-			git worktree add -b "$branch" "$wt_path" 2>/dev/null || true
+			bash -c "git fetch origin '$branch' >/dev/null 2>&1 ||
+				gh issue develop '$gh_issue_number' --name '$branch' >/dev/null 2>&1 || true;
+				git worktree add -B '$branch' '$wt_path' 'origin/$branch' >/dev/null 2>&1 ||
+				git worktree add -b '$branch' '$wt_path' >/dev/null 2>&1 || true"
+
+		if [[ ! -d "$wt_path" ]]; then
+			gum log --level error "Failed to create worktree for issue #$gh_issue_number"
+			return 1
+		fi
 	fi
 
 	local preamble
 	preamble=$(GH_ISSUE_NUMBER="$gh_issue_number" \
 		_cmd_render "$_gh_ai_source_dir/templates/gh_issue_chat.tmpl")
+	if [[ -z "$preamble" ]]; then
+		gum log --level error "Failed to render chat preamble"
+		return 1
+	fi
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.issue.model 2>/dev/null || true)

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -552,7 +552,7 @@ _gh_issue_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$wt_path" "$session_id" "$system_prompt" "$agent_model" \
+	_cmd_chat "$session_file" "$branch" "$session_id" "$system_prompt" "$agent_model" \
 		gh ai issue plan "$gh_issue_number"
 }
 

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -544,7 +544,9 @@ _gh_issue_chat() {
 			git worktree add -b "$branch" "$wt_path" 2>/dev/null || true
 	fi
 
-	local system_prompt="You have been given an implementation plan for GitHub issue #${gh_issue_number}. Present the plan to the user, ask if they want to proceed as-is, refine it, or discuss it further. Only begin implementing once the user explicitly confirms."
+	local preamble
+	preamble=$(GH_ISSUE_NUMBER="$gh_issue_number" \
+		_cmd_render "$_gh_ai_source_dir/templates/gh_issue_chat.tmpl")
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.issue.model 2>/dev/null || true)
@@ -552,7 +554,7 @@ _gh_issue_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$branch" "$session_id" "$system_prompt" "$agent_model" \
+	_cmd_chat "$session_file" "$branch" "$session_id" "$preamble" "$agent_model" \
 		gh ai issue plan "$gh_issue_number"
 }
 

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -531,19 +531,19 @@ _gh_issue_chat() {
 	local session_id session_file
 	_init_claude_session session_id session_file "$repo_name" "I${gh_issue_number}" "$git_dir"
 
-	local branch="issue-${gh_issue_number}"
+	local git_branch="issue-${gh_issue_number}"
 	# shellcheck disable=SC2154
-	local wt_path="$git_dir/.claude/worktrees/${branch}"
+	local git_worktree_path="$git_dir/.claude/worktrees/${git_branch}"
 
 	# Create worktree only if it does not exist; do not auto-merge dev branches
-	if [[ ! -d "$wt_path" ]]; then
+	if [[ ! -d "$git_worktree_path" ]]; then
 		gum spin --title "Setting up Git worktree for GitHub issue #$gh_issue_number..." -- \
-			bash -c "git fetch origin '$branch' >/dev/null 2>&1 ||
-				gh issue develop '$gh_issue_number' --name '$branch' >/dev/null 2>&1 || true;
-				git worktree add -B '$branch' '$wt_path' 'origin/$branch' >/dev/null 2>&1 ||
-				git worktree add -b '$branch' '$wt_path' >/dev/null 2>&1 || true"
+			bash -c "git fetch origin '$git_branch' >/dev/null 2>&1 ||
+				gh issue develop '$gh_issue_number' --name '$git_branch' >/dev/null 2>&1 || true;
+				git worktree add -B '$git_branch' '$git_worktree_path' 'origin/$git_branch' >/dev/null 2>&1 ||
+				git worktree add -b '$git_branch' '$git_worktree_path' >/dev/null 2>&1 || true"
 
-		if [[ ! -d "$wt_path" ]]; then
+		if [[ ! -d "$git_worktree_path" ]]; then
 			gum log --level error "Failed to create worktree for issue #$gh_issue_number"
 			return 1
 		fi
@@ -563,7 +563,7 @@ _gh_issue_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$branch" "$session_id" "$preamble" "$agent_model" \
+	_cmd_chat "$session_file" "$git_branch" "$session_id" "$preamble" "$agent_model" \
 		gh ai issue plan "$gh_issue_number"
 }
 

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -63,7 +63,7 @@ _parse_issue_create_args() {
 		case "${raw_args[$i]}" in
 		--description | -d)
 			if ((i + 1 >= ${#raw_args[@]})); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
 			gh_issue_description_ref="${raw_args[$((i + 1))]}"
@@ -73,11 +73,11 @@ _parse_issue_create_args() {
 			gh_issue_description_ref="${raw_args[$i]#--description=}"
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}' (use -- to pass flags to gh issue create)" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh issue create)"
 			return 1
 			;;
 		*)
-			echo "error: unexpected argument '${raw_args[$i]}'" >&2
+			gum log --level error "unexpected argument '${raw_args[$i]}'"
 			return 1
 			;;
 		esac
@@ -110,18 +110,18 @@ _parse_issue_edit_args() {
 		case "${raw_args[$i]}" in
 		--description | -d)
 			if ((i + 1 >= ${#raw_args[@]})); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
 			gh_issue_description_ref="${raw_args[$((i + 1))]}"
 			skip_next=true
 			;;
 		--description=*)
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_issue_description_ref="${raw_args[$i]#--description=}"
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}' (use -- to pass flags to gh issue edit)" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh issue edit)"
 			return 1
 			;;
 		*)
@@ -129,7 +129,7 @@ _parse_issue_edit_args() {
 			if [[ -z "$gh_issue_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_issue_number_ref="$arg"
 			else
-				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
 				return 1
 			fi
 			;;
@@ -292,18 +292,18 @@ _parse_issue_plan_args() {
 		case "${raw_args[$i]}" in
 		--description | -d)
 			if ((i + 1 >= ${#raw_args[@]})); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
 			gh_issue_description_ref="${raw_args[$((i + 1))]}"
 			skip_next=true
 			;;
 		--description=*)
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_issue_description_ref="${raw_args[$i]#--description=}"
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}'" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}'"
 			return 1
 			;;
 		*)
@@ -311,7 +311,7 @@ _parse_issue_plan_args() {
 			if [[ -z "$gh_issue_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_issue_number_ref="$arg"
 			else
-				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
 				return 1
 			fi
 			;;
@@ -481,7 +481,7 @@ _parse_issue_chat_args() {
 			break
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}'" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}'"
 			return 1
 			;;
 		*)
@@ -489,7 +489,7 @@ _parse_issue_chat_args() {
 			if [[ -z "$gh_issue_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_issue_number_ref="$arg"
 			else
-				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
 				return 1
 			fi
 			;;

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -531,11 +531,9 @@ _gh_issue_chat() {
 
 	# Create worktree only if it does not exist; do not auto-merge dev branches
 	if [[ ! -d "$git_worktree_path" ]]; then
+		# shellcheck disable=SC2154
 		gum spin --title "Setting up Git worktree for GitHub issue #$gh_issue_number..." -- \
-			bash -c "git fetch origin '$git_branch' >/dev/null 2>&1 ||
-				gh issue develop '$gh_issue_number' --name '$git_branch' >/dev/null 2>&1 || true;
-				git worktree add -B '$git_branch' '$git_worktree_path' 'origin/$git_branch' >/dev/null 2>&1 ||
-				git worktree add -b '$git_branch' '$git_worktree_path' >/dev/null 2>&1 || true"
+			"$_gh_ai_source_dir/scripts/gh_cmd.sh" worktree-create "$git_branch" "$git_worktree_path" "$gh_issue_number"
 
 		if [[ ! -d "$git_worktree_path" ]]; then
 			gum log --level error "Failed to create worktree for issue #$gh_issue_number"

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -18,20 +18,24 @@ USAGE:
     gh ai issue create -d <DESCRIPTION> [-- GH_ISSUE_CREATE_OPTIONS]
     gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [-- GH_ISSUE_EDIT_OPTIONS]
     gh ai issue plan <ISSUE_NUMBER>
+    gh ai issue chat <ISSUE_NUMBER>
 
 DESCRIPTION:
     Creates and edits GitHub issues with AI-generated titles and structured
     bodies. Generates implementation plans from issues and prints them to stdout.
+    Opens a Claude Code session seeded with an issue plan in an isolated worktree.
 
 COMMANDS:
     create      Create issues with AI-generated content
     edit        Edit an existing issue with AI-generated content
     plan        Generate an AI implementation plan from an issue
+    chat        Open a Claude Code session seeded with an issue plan
 
 SEE ALSO:
     gh ai issue create --help     # Issue create usage
     gh ai issue edit --help       # Issue edit usage
     gh ai issue plan --help       # Issue plan usage
+    gh ai issue chat --help       # Issue chat usage
 EOF
 }
 
@@ -436,6 +440,122 @@ EXAMPLES:
 EOF
 }
 
+# Issue chat help function
+#
+# Displays help information for the issue chat command.
+_show_issue_chat_help() {
+	cat <<'EOF'
+gh ai issue chat - Open a Claude Code session seeded with an issue plan
+
+USAGE:
+    gh ai issue chat <ISSUE_NUMBER>
+
+DESCRIPTION:
+    Generates an AI implementation plan for the issue (via gh ai issue plan),
+    creates a git worktree on branch issue-N (or reuses an existing one),
+    and opens a Claude Code session seeded with that plan.
+    Claude will present the plan and ask for confirmation before implementing.
+    Re-running the command resumes the previous session.
+
+EXAMPLES:
+    gh ai issue chat 42
+EOF
+}
+
+# Parse issue chat arguments
+#
+# Extracts the issue number (first positional arg, stripping leading #).
+# Unknown flags produce an error.
+#
+# Example: _parse_issue_chat_args num 42
+_parse_issue_chat_args() {
+	local -n gh_issue_number_ref="$1"
+	shift
+
+	local raw_args=("$@")
+	local i=0
+
+	while [[ $i -lt ${#raw_args[@]} ]]; do
+		case "${raw_args[$i]}" in
+		--)
+			break
+			;;
+		-*)
+			echo "error: unknown flag '${raw_args[$i]}'" >&2
+			return 1
+			;;
+		*)
+			local arg="${raw_args[$i]#\#}"
+			if [[ -z "$gh_issue_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
+				gh_issue_number_ref="$arg"
+			else
+				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				return 1
+			fi
+			;;
+		esac
+		((++i))
+	done
+}
+
+# Issue Chat implementation
+#
+# Generates an implementation plan for the issue, creates a git worktree on
+# branch issue-N (or reuses an existing one), and opens a Claude Code session
+# seeded with the plan. Re-running resumes the previous session.
+#
+# Usage: _gh_issue_chat <ISSUE_NUMBER>
+_gh_issue_chat() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_issue_chat_help
+		return 0
+		;;
+	esac
+
+	local gh_issue_number=""
+	_parse_issue_chat_args gh_issue_number "$@"
+
+	if [[ -z "$gh_issue_number" ]]; then
+		gum log --level error "No issue number provided"
+		gum log --level info "Usage: gh ai issue chat <ISSUE_NUMBER>"
+		return 1
+	fi
+
+	local repo_name
+	_get_repo_name repo_name || return 1
+
+	local git_dir
+	_get_git_repo_path git_dir || return 1
+
+	local session_id session_file
+	_init_claude_session session_id session_file "$repo_name" "I${gh_issue_number}" "$git_dir"
+
+	local branch="issue-${gh_issue_number}"
+	# shellcheck disable=SC2154
+	local wt_path="$git_dir/.claude/worktrees/${branch}"
+
+	# Create worktree only if it does not exist; do not auto-merge dev branches
+	if [[ ! -d "$wt_path" ]]; then
+		gum spin --title "Setting up worktree for issue #$gh_issue_number..." -- \
+			git fetch origin "$branch" 2>/dev/null ||
+			gh issue develop "$gh_issue_number" --name "$branch" 2>/dev/null || true
+		git worktree add -B "$branch" "$wt_path" "origin/$branch" 2>/dev/null ||
+			git worktree add -b "$branch" "$wt_path" 2>/dev/null || true
+	fi
+
+	local system_prompt="You have been given an implementation plan for GitHub issue #${gh_issue_number}. Present the plan to the user, ask if they want to proceed as-is, refine it, or discuss it further. Only begin implementing once the user explicitly confirms."
+
+	local agent_model
+	agent_model=$(gh config get gh-ai.issue.model 2>/dev/null || true)
+	if [[ -z "$agent_model" ]]; then
+		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
+	fi
+
+	_cmd_chat "$session_file" "$wt_path" "$session_id" "$system_prompt" "$agent_model" \
+		gh ai issue plan "$gh_issue_number"
+}
+
 # Issue Create implementation
 #
 # Creates a GitHub issue with an AI-generated title and structured body.
@@ -523,7 +643,7 @@ _gh_issue_create() {
 # Shows help for unknown commands.
 #
 # Usage: _gh_issue <subcommand> [OPTIONS]
-# Subcommands: create, edit, plan, help
+# Subcommands: create, edit, plan, chat, help
 _gh_issue() {
 	local subcommand="${1:-}"
 	shift || true
@@ -538,12 +658,15 @@ _gh_issue() {
 	plan)
 		_gh_issue_plan "$@"
 		;;
+	chat)
+		_gh_issue_chat "$@"
+		;;
 	--help | -h | help | "")
 		_show_issue_help
 		;;
 	*)
 		gum log --level error "Unknown issue command '$subcommand'"
-		gum log --level info "Available commands: create, edit, plan"
+		gum log --level info "Available commands: create, edit, plan, chat"
 		gum log --level info "Run 'gh ai issue --help' for usage information"
 		exit 1
 		;;

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -30,7 +30,7 @@ _parse_pr_create_args() {
 
 		case "${raw_args[$i]}" in
 		--description | -d)
-			if (( i + 1 >= ${#raw_args[@]} )); then
+			if ((i + 1 >= ${#raw_args[@]})); then
 				echo "error: ${raw_args[$i]} requires a value" >&2
 				return 1
 			fi
@@ -42,7 +42,7 @@ _parse_pr_create_args() {
 			gh_pr_description_ref="${raw_args[$i]#--description=}"
 			;;
 		--base | -B)
-			if (( i + 1 >= ${#raw_args[@]} )); then
+			if ((i + 1 >= ${#raw_args[@]})); then
 				echo "error: ${raw_args[$i]} requires a value" >&2
 				return 1
 			fi
@@ -233,7 +233,7 @@ _parse_pr_edit_args() {
 
 		case "${raw_args[$i]}" in
 		--description | -d)
-			if (( i + 1 >= ${#raw_args[@]} )); then
+			if ((i + 1 >= ${#raw_args[@]})); then
 				echo "error: ${raw_args[$i]} requires a value" >&2
 				return 1
 			fi
@@ -469,7 +469,7 @@ _parse_pr_review_args() {
 
 		case "${raw_args[$i]}" in
 		--description | -d)
-			if (( i + 1 >= ${#raw_args[@]} )); then
+			if ((i + 1 >= ${#raw_args[@]})); then
 				echo "error: ${raw_args[$i]} requires a value" >&2
 				return 1
 			fi
@@ -734,6 +734,122 @@ _gh_pr_explain() {
 	esac
 }
 
+# PR chat help function
+#
+# Displays help information for the pr chat command.
+_show_pr_chat_help() {
+	cat <<'EOF'
+gh ai pr chat - Open a Claude Code review session for a pull request
+
+USAGE:
+    gh ai pr chat <PR_NUMBER>
+
+DESCRIPTION:
+    Generates a plain-language explanation of the PR (via gh ai pr explain),
+    creates a git worktree on branch pr-N (fast-forwarded to the PR head),
+    and opens a Claude Code session seeded with that explanation.
+    Re-running the command resumes the previous session.
+    The session is opened in discussion mode — Claude will not commit or push changes.
+
+EXAMPLES:
+    gh ai pr chat 99
+EOF
+}
+
+# Parse PR chat arguments
+#
+# Extracts the PR number (first positional arg, stripping leading #).
+# Unknown flags produce an error.
+#
+# Example: _parse_pr_chat_args num 99
+_parse_pr_chat_args() {
+	local -n gh_pr_number_ref="$1"
+	shift
+
+	local raw_args=("$@")
+	local i=0
+
+	while [[ $i -lt ${#raw_args[@]} ]]; do
+		case "${raw_args[$i]}" in
+		--)
+			break
+			;;
+		-*)
+			echo "error: unknown flag '${raw_args[$i]}'" >&2
+			return 1
+			;;
+		*)
+			local arg="${raw_args[$i]#\#}"
+			if [[ -z "$gh_pr_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
+				gh_pr_number_ref="$arg"
+			else
+				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				return 1
+			fi
+			;;
+		esac
+		((++i))
+	done
+}
+
+# PR Chat implementation
+#
+# Generates a plain-language explanation of the PR, creates a git worktree on
+# branch pr-N (synced to the PR head), and opens a Claude Code session seeded
+# with the explanation in discussion mode. Re-running resumes the session.
+#
+# Usage: _gh_pr_chat <PR_NUMBER>
+_gh_pr_chat() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_pr_chat_help
+		return 0
+		;;
+	esac
+
+	local gh_pr_number=""
+	_parse_pr_chat_args gh_pr_number "$@"
+
+	if [[ -z "$gh_pr_number" ]]; then
+		gum log --level error "No PR number provided"
+		gum log --level info "Usage: gh ai pr chat <PR_NUMBER>"
+		return 1
+	fi
+
+	local repo_name
+	_get_repo_name repo_name || return 1
+
+	local git_dir
+	_get_git_repo_path git_dir || return 1
+
+	local session_id session_file
+	_init_claude_session session_id session_file "$repo_name" "P${gh_pr_number}" "$git_dir"
+
+	local remote_branch
+	remote_branch=$(gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' 2>/dev/null || true)
+	if [[ -z "$remote_branch" ]]; then
+		gum log --level error "Failed to fetch head branch for PR #$gh_pr_number"
+		return 1
+	fi
+
+	local branch="pr-${gh_pr_number}"
+	# shellcheck disable=SC2154
+	local wt_path="$git_dir/.claude/worktrees/${branch}"
+
+	_git_worktree_sync "$branch" "$wt_path" "$remote_branch" "PR #$gh_pr_number" || return 1
+
+	local system_prompt="This is a discussion session for GitHub pull request #${gh_pr_number}. You have been given an overview of the changes. Help analyze and discuss the PR — do not commit or push changes."
+
+	local agent_model
+	agent_model=$(gh config get gh-ai.pr.model 2>/dev/null || true)
+	if [[ -z "$agent_model" ]]; then
+		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
+	fi
+
+	_cmd_chat "$session_file" "$wt_path" "$session_id" "$system_prompt" "$agent_model" \
+		gh ai pr explain "$gh_pr_number"
+}
+
 # PR help function
 #
 # Displays comprehensive help information for all PR subcommands
@@ -747,21 +863,25 @@ USAGE:
     gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_EDIT_OPTIONS]
     gh ai pr review [PR_NUMBER] [-d <DESCRIPTION>] [-- GH_PR_REVIEW_OPTIONS]
     gh ai pr explain [PR_NUMBER] [--comment | --edit]
+    gh ai pr chat <PR_NUMBER>
 
 DESCRIPTION:
     Creates, edits, reviews, and explains GitHub pull requests with AI-generated content.
+    Opens a Claude Code review session seeded with a PR explanation in an isolated worktree.
 
 COMMANDS:
     create      Create PRs with AI-generated titles and descriptions
     edit        Edit an existing PR with AI-generated content
     review      Review PRs with AI-generated feedback
     explain     Generate a plain-language explanation of a PR
+    chat        Open a Claude Code review session for a PR
 
 SEE ALSO:
     gh ai pr create --help     # Full list of gh pr create options
     gh ai pr edit --help       # Full list of gh pr edit options
     gh ai pr review --help     # Full list of gh pr review options
     gh ai pr explain --help    # PR explain usage
+    gh ai pr chat --help       # PR chat usage
 EOF
 }
 
@@ -771,7 +891,7 @@ EOF
 # Shows help for unknown commands.
 #
 # Usage: _gh_pr <subcommand> [OPTIONS]
-# Subcommands: create, edit, review, explain, help
+# Subcommands: create, edit, review, explain, chat, help
 _gh_pr() {
 	local subcommand="${1:-}"
 	shift || true
@@ -789,12 +909,15 @@ _gh_pr() {
 	explain)
 		_gh_pr_explain "$@"
 		;;
+	chat)
+		_gh_pr_chat "$@"
+		;;
 	--help | -h | help | "")
 		_show_pr_help
 		;;
 	*)
 		gum log --level error "Unknown pr command '$subcommand'"
-		gum log --level info "Available commands: create, edit, review, explain"
+		gum log --level info "Available commands: create, edit, review, explain, chat"
 		gum log --level info "Run 'gh ai pr --help' for usage information"
 		exit 1
 		;;

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -160,7 +160,7 @@ _gh_pr_create() {
 
 	local git_log_oneline
 	# shellcheck disable=SC2001
-	git_log_oneline=$(echo "$git_log" | sed 's/^[a-f0-9]* /- /')
+	git_log_oneline=$(printf '%s\n' "$git_log" | sed 's/^[a-f0-9]* /- /')
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.pr.model 2>/dev/null || true)
@@ -192,12 +192,6 @@ _gh_pr_create() {
 	local gh_pr_body
 	# Parse body from output
 	gh_pr_body=$(_get_body "$output")
-
-	# Validate we got body content
-	if [[ -z "$gh_pr_body" ]]; then
-		gum log --level error "Failed to extract body from AI content"
-		return 1
-	fi
 
 	# Inject --base into passthrough only if the user explicitly specified it
 	if [[ -n "$user_specified_base" ]]; then
@@ -394,12 +388,6 @@ _gh_pr_edit() {
 	# Parse body from output
 	gh_pr_new_body=$(_get_body "$output")
 
-	# Validate we got body content
-	if [[ -z "$gh_pr_new_body" ]]; then
-		gum log --level error "Failed to extract body from AI content"
-		return 1
-	fi
-
 	# Edit PR with AI-generated content
 	gh pr edit "$gh_pr_number" --title "$gh_pr_new_title" --body "$gh_pr_new_body" "${passthrough[@]}"
 }
@@ -530,7 +518,7 @@ DESCRIPTION:
     if no number is provided. Options after -- are passed directly to
     gh pr review.
 
-OPTIONS:
+FLAGS:
     -d, --description <TEXT>    Additional context for AI review generation
 
 EXAMPLES:
@@ -666,15 +654,13 @@ _gh_pr_explain() {
 		;;
 	esac
 
-	local args=("$@")
-
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_pr_explain.tmpl"
 
 	local gh_pr_number=""
 	local gh_pr_output_mode=""
-	_parse_pr_explain_args gh_pr_number gh_pr_output_mode "${args[@]}"
+	_parse_pr_explain_args gh_pr_number gh_pr_output_mode "$@"
 
 	if [[ -z "$gh_pr_number" ]]; then
 		gum log --level error "No PR number provided and could not detect PR for current branch"
@@ -703,11 +689,15 @@ _gh_pr_explain() {
 		gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' || true)
 
 	# Fetch PR title and body
-	local gh_pr_title
-	gh_pr_title=$(gh pr view "$gh_pr_number" --json title -q '.title' 2>/dev/null || true)
+	local gh_pr_eval
+	gh_pr_eval=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number metadata..." -- \
+		gh pr view "$gh_pr_number" --json title,body \
+		-q "$(<"$_gh_ai_source_dir/scripts/gh_pr_meta.jq")" || true)
 
-	local gh_pr_body
-	gh_pr_body=$(gh pr view "$gh_pr_number" --json body -q '.body' 2>/dev/null || true)
+	local gh_pr_title gh_pr_body
+	if [[ -n "$gh_pr_eval" ]]; then
+		eval "$gh_pr_eval"
+	fi
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.pr.model 2>/dev/null || true)
@@ -934,7 +924,7 @@ _gh_pr() {
 		gum log --level error "Unknown pr command '$subcommand'"
 		gum log --level info "Available commands: create, edit, review, explain, chat"
 		gum log --level info "Run 'gh ai pr --help' for usage information"
-		exit 1
+		return 1
 		;;
 	esac
 }

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -838,7 +838,9 @@ _gh_pr_chat() {
 
 	_git_worktree_sync "$branch" "$wt_path" "$remote_branch" "PR #$gh_pr_number" || return 1
 
-	local system_prompt="This is a discussion session for GitHub pull request #${gh_pr_number}. You have been given an overview of the changes. Help analyze and discuss the PR — do not commit or push changes."
+	local preamble
+	preamble=$(GH_PR_NUMBER="$gh_pr_number" \
+		_cmd_render "$_gh_ai_source_dir/templates/gh_pr_chat.tmpl")
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.pr.model 2>/dev/null || true)
@@ -846,7 +848,7 @@ _gh_pr_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$branch" "$session_id" "$system_prompt" "$agent_model" \
+	_cmd_chat "$session_file" "$branch" "$session_id" "$preamble" "$agent_model" \
 		gh ai pr explain "$gh_pr_number"
 }
 

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -835,7 +835,9 @@ _gh_pr_chat() {
 	local git_branch="pr-${gh_pr_number}"
 	# shellcheck disable=SC2154
 	local git_worktree_path="$git_dir/.claude/worktrees/${git_branch}"
-	_git_worktree_sync "$git_branch" "$git_worktree_path" "$gh_remote_branch" "PR #$gh_pr_number" || return 1
+	# shellcheck disable=SC2154
+	gum spin --title "Setting up Git worktree for GitHub pull request #$gh_pr_number..." -- \
+		"$_gh_ai_source_dir/scripts/gh_cmd.sh" worktree-sync "$git_branch" "$git_worktree_path" "$gh_remote_branch" || return 1
 
 	local preamble
 	preamble=$(GH_PR_NUMBER="$gh_pr_number" \

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -846,7 +846,7 @@ _gh_pr_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$wt_path" "$session_id" "$system_prompt" "$agent_model" \
+	_cmd_chat "$session_file" "$branch" "$session_id" "$system_prompt" "$agent_model" \
 		gh ai pr explain "$gh_pr_number"
 }
 

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -823,7 +823,7 @@ _gh_pr_chat() {
 	_get_git_repo_path git_dir || return 1
 
 	local session_id session_file
-	_init_claude_session session_id session_file "$repo_name" "P${gh_pr_number}" "$git_dir"
+	_init_chat_session session_id session_file "$repo_name" "P${gh_pr_number}" "$git_dir"
 
 	local gh_remote_branch
 	gh_remote_branch=$(gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' 2>/dev/null || true)

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -841,6 +841,10 @@ _gh_pr_chat() {
 	local preamble
 	preamble=$(GH_PR_NUMBER="$gh_pr_number" \
 		_cmd_render "$_gh_ai_source_dir/templates/gh_pr_chat.tmpl")
+	if [[ -z "$preamble" ]]; then
+		gum log --level error "Failed to render chat preamble"
+		return 1
+	fi
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.pr.model 2>/dev/null || true)

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -825,18 +825,17 @@ _gh_pr_chat() {
 	local session_id session_file
 	_init_claude_session session_id session_file "$repo_name" "P${gh_pr_number}" "$git_dir"
 
-	local remote_branch
-	remote_branch=$(gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' 2>/dev/null || true)
-	if [[ -z "$remote_branch" ]]; then
+	local gh_remote_branch
+	gh_remote_branch=$(gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' 2>/dev/null || true)
+	if [[ -z "$gh_remote_branch" ]]; then
 		gum log --level error "Failed to fetch head branch for PR #$gh_pr_number"
 		return 1
 	fi
 
-	local branch="pr-${gh_pr_number}"
+	local git_branch="pr-${gh_pr_number}"
 	# shellcheck disable=SC2154
-	local wt_path="$git_dir/.claude/worktrees/${branch}"
-
-	_git_worktree_sync "$branch" "$wt_path" "$remote_branch" "PR #$gh_pr_number" || return 1
+	local git_worktree_path="$git_dir/.claude/worktrees/${git_branch}"
+	_git_worktree_sync "$git_branch" "$git_worktree_path" "$gh_remote_branch" "PR #$gh_pr_number" || return 1
 
 	local preamble
 	preamble=$(GH_PR_NUMBER="$gh_pr_number" \
@@ -852,7 +851,7 @@ _gh_pr_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$branch" "$session_id" "$preamble" "$agent_model" \
+	_cmd_chat "$session_file" "$git_branch" "$session_id" "$preamble" "$agent_model" \
 		gh ai pr explain "$gh_pr_number"
 }
 

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -31,35 +31,35 @@ _parse_pr_create_args() {
 		case "${raw_args[$i]}" in
 		--description | -d)
 			if ((i + 1 >= ${#raw_args[@]})); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
 			gh_pr_description_ref="${raw_args[$((i + 1))]}"
 			skip_next=true
 			;;
 		--description=*)
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_pr_description_ref="${raw_args[$i]#--description=}"
 			;;
 		--base | -B)
 			if ((i + 1 >= ${#raw_args[@]})); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			git_base_branch_ref="${raw_args[$((i + 1))]}"
 			skip_next=true
 			;;
 		--base=*)
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			git_base_branch_ref="${raw_args[$i]#--base=}"
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr create)" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr create)"
 			return 1
 			;;
 		*)
-			echo "error: unexpected argument '${raw_args[$i]}'" >&2
+			gum log --level error "unexpected argument '${raw_args[$i]}'"
 			return 1
 			;;
 		esac
@@ -234,18 +234,18 @@ _parse_pr_edit_args() {
 		case "${raw_args[$i]}" in
 		--description | -d)
 			if ((i + 1 >= ${#raw_args[@]})); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
 			gh_pr_description_ref="${raw_args[$((i + 1))]}"
 			skip_next=true
 			;;
 		--description=*)
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_pr_description_ref="${raw_args[$i]#--description=}"
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr edit)" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr edit)"
 			return 1
 			;;
 		*)
@@ -253,7 +253,7 @@ _parse_pr_edit_args() {
 			if [[ -z "$gh_pr_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_pr_number_ref="$arg"
 			else
-				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
 				return 1
 			fi
 			;;
@@ -420,17 +420,27 @@ _parse_pr_explain_args() {
 
 	while [[ $i -lt ${#raw_args[@]} ]]; do
 		case "${raw_args[$i]}" in
+		--)
+			break
+			;;
 		--comment)
 			gh_pr_output_mode_ref="comment"
 			;;
 		--edit)
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_pr_output_mode_ref="edit"
+			;;
+		-*)
+			gum log --level error "unknown flag '${raw_args[$i]}'"
+			return 1
 			;;
 		*)
 			local arg="${raw_args[$i]#\#}"
 			if [[ -z "$gh_pr_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_pr_number_ref="$arg"
+			else
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
+				return 1
 			fi
 			;;
 		esac
@@ -452,7 +462,7 @@ _parse_pr_explain_args() {
 # Example: _parse_pr_review_args num desc 42 -d "focus on security"
 _parse_pr_review_args() {
 	local -n gh_pr_number_ref="$1"
-	# shellcheck disable=SC2178
+	# shellcheck disable=SC2178 # bash nameref: looks like scalar redefining array, but it's a reference
 	local -n gh_pr_description_ref="$2"
 	shift 2
 
@@ -470,18 +480,18 @@ _parse_pr_review_args() {
 		case "${raw_args[$i]}" in
 		--description | -d)
 			if ((i + 1 >= ${#raw_args[@]})); then
-				echo "error: ${raw_args[$i]} requires a value" >&2
+				gum log --level error "${raw_args[$i]} requires a value"
 				return 1
 			fi
 			gh_pr_description_ref="${raw_args[$((i + 1))]}"
 			skip_next=true
 			;;
 		--description=*)
-			# shellcheck disable=SC2034
+			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_pr_description_ref="${raw_args[$i]#--description=}"
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr review)" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr review)"
 			return 1
 			;;
 		*)
@@ -489,7 +499,7 @@ _parse_pr_review_args() {
 			if [[ -z "$gh_pr_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_pr_number_ref="$arg"
 			else
-				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
 				return 1
 			fi
 			;;
@@ -707,7 +717,7 @@ _gh_pr_explain() {
 	output=$(
 		gum spin --title "Generating GitHub pull request #$gh_pr_number explanation..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" assist "$agent_model" < <(
-				PR_TITLE="$gh_pr_title" PR_BODY="$gh_pr_body" GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" \
+				GH_PR_TITLE="$gh_pr_title" GH_PR_BODY="$gh_pr_body" GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" \
 					GIT_COMMITS="$git_commit_list" GIT_BRANCH="$git_branch" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
@@ -775,7 +785,7 @@ _parse_pr_chat_args() {
 			break
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}'" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}'"
 			return 1
 			;;
 		*)
@@ -783,7 +793,7 @@ _parse_pr_chat_args() {
 			if [[ -z "$gh_pr_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_pr_number_ref="$arg"
 			else
-				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
 				return 1
 			fi
 			;;

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -142,7 +142,9 @@ _gh_run_chat() {
 	local git_branch="run-${gh_run_id}"
 	# shellcheck disable=SC2154
 	local git_worktree_path="$git_dir/.claude/worktrees/${git_branch}"
-	_git_worktree_sync "$git_branch" "$git_worktree_path" "$gh_remote_branch" "run #$gh_run_id" || return 1
+	# shellcheck disable=SC2154
+	gum spin --title "Setting up Git worktree for GitHub workflow run #$gh_run_id..." -- \
+		"$_gh_ai_source_dir/scripts/gh_cmd.sh" worktree-sync "$git_branch" "$git_worktree_path" "$gh_remote_branch" || return 1
 
 	local preamble
 	# shellcheck disable=SC2154

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -28,6 +28,122 @@ _parse_run_explain_args() {
 	done
 }
 
+# Run chat help function
+#
+# Displays help information for the run chat command.
+_show_run_chat_help() {
+	cat <<'EOF'
+gh ai run chat - Open a Claude Code debug session for a workflow run
+
+USAGE:
+    gh ai run chat <RUN_ID>
+
+DESCRIPTION:
+    Generates an AI explanation of the workflow run (via gh ai run explain),
+    creates a git worktree on the run's head branch (fast-forwarded),
+    and opens a Claude Code session seeded with that explanation.
+    Re-running the command resumes the previous session.
+    The session is focused on analyzing the failure and helping fix issues.
+
+EXAMPLES:
+    gh ai run chat 12345678
+EOF
+}
+
+# Parse run chat arguments
+#
+# Extracts the run ID (first positional arg, stripping leading #).
+# Unknown flags produce an error.
+#
+# Example: _parse_run_chat_args id 12345678
+_parse_run_chat_args() {
+	local -n gh_run_id_ref="$1"
+	shift
+
+	local raw_args=("$@")
+	local i=0
+
+	while [[ $i -lt ${#raw_args[@]} ]]; do
+		case "${raw_args[$i]}" in
+		--)
+			break
+			;;
+		-*)
+			echo "error: unknown flag '${raw_args[$i]}'" >&2
+			return 1
+			;;
+		*)
+			local arg="${raw_args[$i]#\#}"
+			if [[ -z "$gh_run_id_ref" && "$arg" =~ ^[0-9]+$ ]]; then
+				gh_run_id_ref="$arg"
+			else
+				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				return 1
+			fi
+			;;
+		esac
+		((++i))
+	done
+}
+
+# Run Chat implementation
+#
+# Generates an explanation of the workflow run, creates a git worktree on the
+# run's head branch (synced to remote), and opens a Claude Code session seeded
+# with the explanation for debugging. Re-running resumes the session.
+#
+# Usage: _gh_run_chat <RUN_ID>
+_gh_run_chat() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_run_chat_help
+		return 0
+		;;
+	esac
+
+	local gh_run_id=""
+	_parse_run_chat_args gh_run_id "$@"
+
+	if [[ -z "$gh_run_id" ]]; then
+		gum log --level error "No run ID provided"
+		gum log --level info "Usage: gh ai run chat <RUN_ID>"
+		return 1
+	fi
+
+	local repo_name
+	_get_repo_name repo_name || return 1
+
+	local git_dir
+	_get_git_repo_path git_dir || return 1
+
+	local session_id session_file
+	_init_claude_session session_id session_file "$repo_name" "R${gh_run_id}" "$git_dir"
+
+	local remote_branch
+	remote_branch=$(gh run view "$gh_run_id" --json headBranch -q '.headBranch' 2>/dev/null || true)
+	if [[ -z "$remote_branch" ]]; then
+		gum log --level error "Failed to fetch head branch for run $gh_run_id"
+		return 1
+	fi
+
+	local branch="run-${gh_run_id}"
+	# shellcheck disable=SC2154
+	local wt_path="$git_dir/.claude/worktrees/${branch}"
+
+	_git_worktree_sync "$branch" "$wt_path" "$remote_branch" "run $gh_run_id" || return 1
+
+	local system_prompt="This is a debug session for GitHub Actions run #${gh_run_id}. Analyze the failure and help fix the issues."
+
+	local agent_model
+	agent_model=$(gh config get gh-ai.run.model 2>/dev/null || true)
+	if [[ -z "$agent_model" ]]; then
+		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
+	fi
+
+	_cmd_chat "$session_file" "$wt_path" "$session_id" "$system_prompt" "$agent_model" \
+		gh ai run explain "$gh_run_id"
+}
+
 # Run help function
 #
 # Displays comprehensive help information for all run subcommands
@@ -38,15 +154,19 @@ gh ai run - Workflow run commands with AI assistance
 
 USAGE:
     gh ai run explain <RUN_ID>
+    gh ai run chat <RUN_ID>
 
 DESCRIPTION:
     Analyzes GitHub Actions workflow runs and explains what happened.
+    Opens a Claude Code debug session seeded with a run explanation in an isolated worktree.
 
 COMMANDS:
     explain     Analyze a workflow run and explain failures
+    chat        Open a Claude Code debug session for a workflow run
 
 SEE ALSO:
     gh ai run explain --help    # Run explain usage
+    gh ai run chat --help       # Run chat usage
 EOF
 }
 
@@ -161,7 +281,7 @@ _gh_run_explain() {
 # Shows help for unknown commands.
 #
 # Usage: _gh_run <subcommand> [OPTIONS]
-# Subcommands: explain, help
+# Subcommands: explain, chat, help
 _gh_run() {
 	local subcommand="${1:-}"
 	shift || true
@@ -170,12 +290,15 @@ _gh_run() {
 	explain)
 		_gh_run_explain "$@"
 		;;
+	chat)
+		_gh_run_chat "$@"
+		;;
 	--help | -h | help | "")
 		_show_run_help
 		;;
 	*)
 		gum log --level error "Unknown run command '$subcommand'"
-		gum log --level info "Available commands: explain"
+		gum log --level info "Available commands: explain, chat"
 		gum log --level info "Run 'gh ai run --help' for usage information"
 		exit 1
 		;;

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -122,19 +122,23 @@ _gh_run_chat() {
 	local remote_branch
 	remote_branch=$(gh run view "$gh_run_id" --json headBranch -q '.headBranch' 2>/dev/null || true)
 	if [[ -z "$remote_branch" ]]; then
-		gum log --level error "Failed to fetch head branch for run $gh_run_id"
+		gum log --level error "Failed to fetch head branch for run #$gh_run_id"
 		return 1
 	fi
 
 	local branch="run-${gh_run_id}"
 	# shellcheck disable=SC2154
-	local wt_path="$git_dir/.claude/worktrees/${branch}"
+	local git_worktree_path="$git_dir/.claude/worktrees/${branch}"
 
-	_git_worktree_sync "$branch" "$wt_path" "$remote_branch" "run $gh_run_id" || return 1
+	_git_worktree_sync "$branch" "$git_worktree_path" "$remote_branch" "run #$gh_run_id" || return 1
 
 	local preamble
-	preamble=$(GH_RUN_ID="$gh_run_id" \
-		_cmd_render "$_gh_ai_source_dir/templates/gh_run_chat.tmpl")
+	preamble=$(
+		# shellcheck disable=SC2034
+		GH_RUN_ID="$gh_run_id"
+		# shellcheck disable=SC2154
+		_cmd_render "$_gh_ai_source_dir/templates/gh_run_chat.tmpl"
+	)
 	if [[ -z "$preamble" ]]; then
 		gum log --level error "Failed to render chat preamble"
 		return 1
@@ -232,7 +236,7 @@ _gh_run_explain() {
 		gh run view "$gh_run_id" --json displayTitle,conclusion,url,event,headBranch,jobs \
 		-q "$(<"$_gh_ai_source_dir/scripts/gh_run_meta.jq")" || true)
 	if [[ -z "$gh_run_eval" ]]; then
-		gum log --level error "Failed to fetch run $gh_run_id"
+		gum log --level error "Failed to fetch run #$gh_run_id"
 		return 1
 	fi
 

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -140,7 +140,7 @@ _gh_run_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$wt_path" "$session_id" "$system_prompt" "$agent_model" \
+	_cmd_chat "$session_file" "$branch" "$session_id" "$system_prompt" "$agent_model" \
 		gh ai run explain "$gh_run_id"
 }
 

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -130,7 +130,7 @@ _gh_run_chat() {
 	_get_git_repo_path git_dir || return 1
 
 	local session_id session_file
-	_init_claude_session session_id session_file "$repo_name" "R${gh_run_id}" "$git_dir"
+	_init_chat_session session_id session_file "$repo_name" "R${gh_run_id}" "$git_dir"
 
 	local gh_remote_branch
 	gh_remote_branch=$(gh run view "$gh_run_id" --json headBranch -q '.headBranch' 2>/dev/null || true)

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -145,12 +145,9 @@ _gh_run_chat() {
 	_git_worktree_sync "$git_branch" "$git_worktree_path" "$gh_remote_branch" "run #$gh_run_id" || return 1
 
 	local preamble
-	preamble=$(
-		# shellcheck disable=SC2034 # exported to env for _cmd_render template substitution
-		GH_RUN_ID="$gh_run_id"
-		# shellcheck disable=SC2154
-		_cmd_render "$_gh_ai_source_dir/templates/gh_run_chat.tmpl"
-	)
+	# shellcheck disable=SC2154
+	preamble=$(GH_RUN_ID="$gh_run_id" \
+		_cmd_render "$_gh_ai_source_dir/templates/gh_run_chat.tmpl")
 	if [[ -z "$preamble" ]]; then
 		gum log --level error "Failed to render chat preamble"
 		return 1
@@ -228,14 +225,12 @@ _gh_run_explain() {
 		;;
 	esac
 
-	local args=("$@")
-
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_ai_source_dir/templates/gh_run_explain.tmpl"
 
 	local gh_run_id=""
-	_parse_run_explain_args gh_run_id "${args[@]}"
+	_parse_run_explain_args gh_run_id "$@"
 	if [[ -z "$gh_run_id" ]]; then
 		gum log --level error "No run ID provided"
 		gum log --level info "Usage: gh ai run explain <RUN_ID>"
@@ -322,7 +317,7 @@ _gh_run() {
 		gum log --level error "Unknown run command '$subcommand'"
 		gum log --level info "Available commands: explain, chat"
 		gum log --level info "Run 'gh ai run --help' for usage information"
-		exit 1
+		return 1
 		;;
 	esac
 }

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -135,6 +135,10 @@ _gh_run_chat() {
 	local preamble
 	preamble=$(GH_RUN_ID="$gh_run_id" \
 		_cmd_render "$_gh_ai_source_dir/templates/gh_run_chat.tmpl")
+	if [[ -z "$preamble" ]]; then
+		gum log --level error "Failed to render chat preamble"
+		return 1
+	fi
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.run.model 2>/dev/null || true)

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -15,15 +15,28 @@ _parse_run_explain_args() {
 	local -n gh_run_id_ref="$1"
 	shift
 
-	local args=("$@")
+	local raw_args=("$@")
 	local i=0
 
-	while [[ $i -lt ${#args[@]} ]]; do
-		local arg="${args[$i]#\#}"
-		if [[ -z "$gh_run_id_ref" && "$arg" =~ ^[0-9]+$ ]]; then
-			gh_run_id_ref="$arg"
-			return 0
-		fi
+	while [[ $i -lt ${#raw_args[@]} ]]; do
+		case "${raw_args[$i]}" in
+		--)
+			break
+			;;
+		-*)
+			gum log --level error "unknown flag '${raw_args[$i]}'"
+			return 1
+			;;
+		*)
+			local arg="${raw_args[$i]#\#}"
+			if [[ -z "$gh_run_id_ref" && "$arg" =~ ^[0-9]+$ ]]; then
+				gh_run_id_ref="$arg"
+			else
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
+				return 1
+			fi
+			;;
+		esac
 		((++i))
 	done
 }
@@ -69,7 +82,7 @@ _parse_run_chat_args() {
 			break
 			;;
 		-*)
-			echo "error: unknown flag '${raw_args[$i]}'" >&2
+			gum log --level error "unknown flag '${raw_args[$i]}'"
 			return 1
 			;;
 		*)
@@ -77,7 +90,7 @@ _parse_run_chat_args() {
 			if [[ -z "$gh_run_id_ref" && "$arg" =~ ^[0-9]+$ ]]; then
 				gh_run_id_ref="$arg"
 			else
-				echo "error: unexpected argument '${raw_args[$i]}'" >&2
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
 				return 1
 			fi
 			;;
@@ -133,7 +146,7 @@ _gh_run_chat() {
 
 	local preamble
 	preamble=$(
-		# shellcheck disable=SC2034
+		# shellcheck disable=SC2034 # exported to env for _cmd_render template substitution
 		GH_RUN_ID="$gh_run_id"
 		# shellcheck disable=SC2154
 		_cmd_render "$_gh_ai_source_dir/templates/gh_run_chat.tmpl"

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -119,18 +119,17 @@ _gh_run_chat() {
 	local session_id session_file
 	_init_claude_session session_id session_file "$repo_name" "R${gh_run_id}" "$git_dir"
 
-	local remote_branch
-	remote_branch=$(gh run view "$gh_run_id" --json headBranch -q '.headBranch' 2>/dev/null || true)
-	if [[ -z "$remote_branch" ]]; then
+	local gh_remote_branch
+	gh_remote_branch=$(gh run view "$gh_run_id" --json headBranch -q '.headBranch' 2>/dev/null || true)
+	if [[ -z "$gh_remote_branch" ]]; then
 		gum log --level error "Failed to fetch head branch for run #$gh_run_id"
 		return 1
 	fi
 
-	local branch="run-${gh_run_id}"
+	local git_branch="run-${gh_run_id}"
 	# shellcheck disable=SC2154
-	local git_worktree_path="$git_dir/.claude/worktrees/${branch}"
-
-	_git_worktree_sync "$branch" "$git_worktree_path" "$remote_branch" "run #$gh_run_id" || return 1
+	local git_worktree_path="$git_dir/.claude/worktrees/${git_branch}"
+	_git_worktree_sync "$git_branch" "$git_worktree_path" "$gh_remote_branch" "run #$gh_run_id" || return 1
 
 	local preamble
 	preamble=$(
@@ -150,7 +149,7 @@ _gh_run_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$branch" "$session_id" "$preamble" "$agent_model" \
+	_cmd_chat "$session_file" "$git_branch" "$session_id" "$preamble" "$agent_model" \
 		gh ai run explain "$gh_run_id"
 }
 

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -132,7 +132,9 @@ _gh_run_chat() {
 
 	_git_worktree_sync "$branch" "$wt_path" "$remote_branch" "run $gh_run_id" || return 1
 
-	local system_prompt="This is a debug session for GitHub Actions run #${gh_run_id}. Analyze the failure and help fix the issues."
+	local preamble
+	preamble=$(GH_RUN_ID="$gh_run_id" \
+		_cmd_render "$_gh_ai_source_dir/templates/gh_run_chat.tmpl")
 
 	local agent_model
 	agent_model=$(gh config get gh-ai.run.model 2>/dev/null || true)
@@ -140,7 +142,7 @@ _gh_run_chat() {
 		agent_model=$(gh config get gh-ai.model 2>/dev/null || true)
 	fi
 
-	_cmd_chat "$session_file" "$branch" "$session_id" "$system_prompt" "$agent_model" \
+	_cmd_chat "$session_file" "$branch" "$session_id" "$preamble" "$agent_model" \
 		gh ai run explain "$gh_run_id"
 }
 

--- a/templates/gh_issue_chat.tmpl
+++ b/templates/gh_issue_chat.tmpl
@@ -1,0 +1,1 @@
+IMPORTANT: Your first message contains a pre-generated implementation plan for GitHub issue #${GH_ISSUE_NUMBER}. Output the plan directly in your reply — do not use tools, read files, or explore the codebase. Then ask if the user wants to proceed as-is, refine the plan, or discuss it. Only begin implementing once the user explicitly confirms.

--- a/templates/gh_pr_chat.tmpl
+++ b/templates/gh_pr_chat.tmpl
@@ -1,0 +1,1 @@
+IMPORTANT: Your first message contains a pre-generated explanation of GitHub pull request #${GH_PR_NUMBER}. Output the explanation directly in your reply — do not use tools, read files, or re-analyze the diff. Then ask how the user would like to proceed — review specific areas, discuss trade-offs, or ask questions. Do not commit or push changes unless the user explicitly asks.

--- a/templates/gh_pr_explain.tmpl
+++ b/templates/gh_pr_explain.tmpl
@@ -1,12 +1,12 @@
 Explain what this pull request does in clear, accessible language.
 
 <pr>
-Title: ${PR_TITLE}
+Title: ${GH_PR_TITLE}
 Branch: ${GIT_BRANCH}
 </pr>
 
 <current_description>
-${PR_BODY}
+${GH_PR_BODY}
 </current_description>
 
 <diffstat>

--- a/templates/gh_run_chat.tmpl
+++ b/templates/gh_run_chat.tmpl
@@ -1,0 +1,1 @@
+IMPORTANT: Your first message contains a pre-generated analysis of GitHub Actions run #${GH_RUN_ID}. Output the analysis directly in your reply — do not use tools, re-fetch logs, or generate a new analysis. Then ask how the user would like to proceed — investigate specific failures, discuss fixes, or start implementing. Only begin making changes once the user explicitly confirms.

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -351,48 +351,19 @@ setup() {
 	[[ "$resume_id" == "test-uuid" ]]
 }
 
-@test "_cmd_chat: passes system prompt when provided" {
-	local tmpdir="$BATS_TMPDIR/chat-run-sysprompt-test-$$"
+@test "_cmd_chat: passes preamble as last positional argument" {
+	local tmpdir="$BATS_TMPDIR/chat-run-preamble-test-$$"
 	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 
-	export _claude_out="$tmpdir/claude-sysprompt"
-	claude() {
-		local prev=""
-		for arg in "$@"; do
-			if [[ "$prev" == "--append-system-prompt" ]]; then
-				echo "$arg" >"$_claude_out"
-			fi
-			prev="$arg"
-		done
-	}
+	export _claude_out="$tmpdir/claude-last-arg"
+	claude() { echo "${!#}" >"$_claude_out"; }
 	export -f claude
 
-	_cmd_chat "$session_file" "issue-42" "test-uuid" "Do not modify code." "" \
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "IMPORTANT: Do not modify code." "" \
 		echo "plan"
 
-	[[ "$(cat "$_claude_out")" == "Do not modify code." ]]
-}
-
-@test "_cmd_chat: omits system prompt flag when prompt is empty" {
-	local tmpdir="$BATS_TMPDIR/chat-run-noprompt-test-$$"
-	mkdir -p "$tmpdir"
-	local session_file="$tmpdir/session-abc"
-
-	local saw_append=false
-	claude() {
-		for arg in "$@"; do
-			if [[ "$arg" == "--append-system-prompt" ]]; then
-				saw_append=true
-			fi
-		done
-	}
-	export -f claude
-
-	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "" \
-		echo "plan"
-
-	[[ "$saw_append" == false ]]
+	[[ "$(cat "$_claude_out")" == "IMPORTANT: Do not modify code." ]]
 }
 
 @test "_cmd_chat: errors when provider is not supported" {

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -206,19 +206,7 @@ setup() {
 	}
 	export -f git
 
-	gum() {
-		case "$1" in
-		spin)
-			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
-			[[ $# -gt 0 ]] && shift
-			"$@" || true
-			;;
-		log) ;;
-		esac
-	}
-	export -f gum
-
-	_git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch" "PR #99"
+	_git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch"
 
 	[[ "$fetch_called" == true ]]
 	[[ "$worktree_called" == true ]]
@@ -238,19 +226,7 @@ setup() {
 	}
 	export -f git
 
-	gum() {
-		case "$1" in
-		spin)
-			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
-			[[ $# -gt 0 ]] && shift
-			"$@" || true
-			;;
-		log) ;;
-		esac
-	}
-	export -f gum
-
-	_git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch" "PR #99"
+	_git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch"
 
 	[[ "$merge_called" == true ]]
 }
@@ -267,21 +243,7 @@ setup() {
 	}
 	export -f git
 
-	# Do NOT swallow errors with || true so the || { return 1; } block in
-	# _git_worktree_sync fires when git merge --ff-only fails.
-	gum() {
-		case "$1" in
-		spin)
-			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
-			[[ $# -gt 0 ]] && shift
-			"$@"
-			;;
-		log) ;;
-		esac
-	}
-	export -f gum
-
-	run _git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch" "PR #99"
+	run _git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch"
 
 	[[ "$status" -eq 1 ]]
 }

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -22,7 +22,7 @@ setup() {
 		export _gh_ai_source_dir="$REPO_ROOT"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _split_on_separator \
+		declare -f _split_on_separator _cmd_render _get_title _get_body \
 			_get_repo_name _get_git_repo_path _init_claude_session \
 			_git_worktree_sync _cmd_chat
 	)"
@@ -424,4 +424,131 @@ setup() {
 	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "" echo "plan"
 
 	[[ "$saw_model" == false ]]
+}
+
+# ---------------------------------------------------------------------------
+# _cmd_render
+# ---------------------------------------------------------------------------
+
+@test "_cmd_render: substitutes env vars in template" {
+	local tmpdir="$BATS_TMPDIR/render-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Hello ${MY_NAME}, welcome to ${MY_PLACE}.\n' >"$tmpdir/test.tmpl"
+
+	local output
+	output=$(MY_NAME="Alice" MY_PLACE="Wonderland" _cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *"Hello Alice, welcome to Wonderland."* ]]
+}
+
+@test "_cmd_render: leaves unset vars as empty strings" {
+	local tmpdir="$BATS_TMPDIR/render-unset-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Value: [${UNSET_VAR}]\n' >"$tmpdir/test.tmpl"
+
+	local output
+	output=$(_cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *"Value: []"* ]]
+}
+
+@test "_cmd_render: does not re-expand vars inside substituted values" {
+	local tmpdir="$BATS_TMPDIR/render-safe-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Diff: ${GIT_DIFF}\n' >"$tmpdir/test.tmpl"
+
+	local output
+	output=$(GIT_DIFF='contains ${SECRET} token' _cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *'contains ${SECRET} token'* ]]
+}
+
+@test "_cmd_render: returns error for missing template file" {
+	run _cmd_render "/nonexistent/template.tmpl"
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_cmd_render: preserves multiline content in substituted values" {
+	local tmpdir="$BATS_TMPDIR/render-multiline-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Log:\n${MY_LOG}\nEnd.\n' >"$tmpdir/test.tmpl"
+
+	local output
+	output=$(MY_LOG=$'line one\nline two\nline three' _cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *"line one"* ]]
+	[[ "$output" == *"line two"* ]]
+	[[ "$output" == *"line three"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# _get_title
+# ---------------------------------------------------------------------------
+
+@test "_get_title: extracts title from markdown heading" {
+	local output
+	output=$(_get_title "# Fix bug in parser
+
+Description of the fix.")
+
+	[[ "$output" == "Fix bug in parser" ]]
+}
+
+@test "_get_title: extracts title without heading prefix" {
+	local output
+	output=$(_get_title "Add new feature
+
+Body text here.")
+
+	[[ "$output" == "Add new feature" ]]
+}
+
+@test "_get_title: returns error for empty content" {
+	run _get_title ""
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_get_title: strips only the first heading hash" {
+	local output
+	output=$(_get_title "## Sub heading title")
+
+	[[ "$output" == "# Sub heading title" ]]
+}
+
+# ---------------------------------------------------------------------------
+# _get_body
+# ---------------------------------------------------------------------------
+
+@test "_get_body: extracts body after title line with footer" {
+	local output
+	output=$(_get_body "# Title
+
+Body paragraph one.
+
+Body paragraph two.")
+
+	[[ "$output" == *"Body paragraph one."* ]]
+	[[ "$output" == *"Body paragraph two."* ]]
+	[[ "$output" == *"markdownlint-disable-file"* ]]
+}
+
+@test "_get_body: strips leading blank lines" {
+	local output
+	output=$(_get_body "# Title
+
+
+Actual body.")
+
+	# First char of output should not be a newline
+	[[ "${output:0:1}" != $'\n' ]]
+	[[ "$output" == *"Actual body."* ]]
+}
+
+@test "_get_body: returns only footer for title-only content" {
+	local output
+	output=$(_get_body "# Title only")
+
+	[[ "$output" == *"markdownlint-disable-file"* ]]
 }

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -292,11 +292,9 @@ setup() {
 
 @test "_cmd_chat: starts new session when sentinel file is absent" {
 	local tmpdir="$BATS_TMPDIR/chat-run-new-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 
-	# claude runs on the right side of a pipe (subshell) — use a file to
-	# capture the --session-id value instead of an in-process variable.
 	export _claude_out="$tmpdir/claude-session-id"
 	claude() {
 		local prev=""
@@ -309,7 +307,7 @@ setup() {
 	}
 	export -f claude
 
-	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "" \
 		echo "plan content"
 
 	[[ "$(cat "$_claude_out")" == "test-uuid" ]]
@@ -318,13 +316,13 @@ setup() {
 
 @test "_cmd_chat: touches sentinel file after successful new session" {
 	local tmpdir="$BATS_TMPDIR/chat-run-touch-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-xyz"
 
 	claude() { :; }
 	export -f claude
 
-	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "" \
 		echo "plan content"
 
 	[[ -f "$session_file" ]]
@@ -332,7 +330,7 @@ setup() {
 
 @test "_cmd_chat: resumes session when sentinel file exists" {
 	local tmpdir="$BATS_TMPDIR/chat-run-resume-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 	touch "$session_file"
 
@@ -347,7 +345,7 @@ setup() {
 	}
 	export -f claude
 
-	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "" \
 		echo "plan content"
 
 	[[ "$resume_id" == "test-uuid" ]]
@@ -355,10 +353,9 @@ setup() {
 
 @test "_cmd_chat: passes system prompt when provided" {
 	local tmpdir="$BATS_TMPDIR/chat-run-sysprompt-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 
-	# Same subshell issue — capture via file.
 	export _claude_out="$tmpdir/claude-sysprompt"
 	claude() {
 		local prev=""
@@ -371,7 +368,7 @@ setup() {
 	}
 	export -f claude
 
-	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "Do not modify code." "" \
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "Do not modify code." "" \
 		echo "plan"
 
 	[[ "$(cat "$_claude_out")" == "Do not modify code." ]]
@@ -379,7 +376,7 @@ setup() {
 
 @test "_cmd_chat: omits system prompt flag when prompt is empty" {
 	local tmpdir="$BATS_TMPDIR/chat-run-noprompt-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 
 	local saw_append=false
@@ -392,7 +389,7 @@ setup() {
 	}
 	export -f claude
 
-	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "" \
 		echo "plan"
 
 	[[ "$saw_append" == false ]]
@@ -400,7 +397,7 @@ setup() {
 
 @test "_cmd_chat: errors when provider is not supported" {
 	local tmpdir="$BATS_TMPDIR/chat-provider-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 
 	gh() {
@@ -411,14 +408,14 @@ setup() {
 	}
 	export -f gh
 
-	run _cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" echo "plan"
+	run _cmd_chat "$session_file" "issue-42" "test-uuid" "" "" echo "plan"
 
 	[[ "$status" -eq 1 ]]
 }
 
 @test "_cmd_chat: passes --model when model arg is non-empty" {
 	local tmpdir="$BATS_TMPDIR/chat-model-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 
 	export _claude_out="$tmpdir/claude-model"
@@ -433,14 +430,14 @@ setup() {
 	}
 	export -f claude
 
-	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "claude-opus-4-5" echo "plan"
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "claude-opus-4-5" echo "plan"
 
 	[[ "$(cat "$_claude_out")" == "claude-opus-4-5" ]]
 }
 
 @test "_cmd_chat: omits --model when no model is configured" {
 	local tmpdir="$BATS_TMPDIR/chat-no-model-test-$$"
-	mkdir -p "$tmpdir/wt"
+	mkdir -p "$tmpdir"
 	local session_file="$tmpdir/session-abc"
 
 	local saw_model=false
@@ -453,7 +450,7 @@ setup() {
 	}
 	export -f claude
 
-	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" echo "plan"
+	_cmd_chat "$session_file" "issue-42" "test-uuid" "" "" echo "plan"
 
 	[[ "$saw_model" == false ]]
 }

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -23,7 +23,7 @@ setup() {
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _split_on_separator _cmd_render _get_title _get_body \
-			_get_repo_name _get_git_repo_path _init_claude_session \
+			_get_repo_name _get_git_repo_path _init_chat_session \
 			_git_worktree_sync _cmd_chat
 	)"
 }
@@ -160,28 +160,28 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
-# _init_claude_session
+# _init_chat_session
 # ---------------------------------------------------------------------------
 
-@test "_init_claude_session: populates session ID and file path" {
+@test "_init_chat_session: populates session ID and file path" {
 	uuid() { echo "deadbeef-dead-beef-dead-beefdeadbeef"; }
 	export -f uuid
 
 	local tmpdir="$BATS_TMPDIR/init-session-test-$$"
 	local id="" file=""
-	_init_claude_session id file "owner/repo" "I42" "$tmpdir"
+	_init_chat_session id file "owner/repo" "I42" "$tmpdir"
 
 	[[ "$id" == "deadbeef-dead-beef-dead-beefdeadbeef" ]]
 	[[ "$file" == "$tmpdir/.claude/sessions/deadbeef-dead-beef-dead-beefdeadbeef" ]]
 }
 
-@test "_init_claude_session: creates session directory" {
+@test "_init_chat_session: creates session directory" {
 	uuid() { echo "deadbeef-dead-beef-dead-beefdeadbeef"; }
 	export -f uuid
 
 	local tmpdir="$BATS_TMPDIR/init-session-mkdir-test-$$"
 	local id="" file=""
-	_init_claude_session id file "owner/repo" "P99" "$tmpdir"
+	_init_chat_session id file "owner/repo" "P99" "$tmpdir"
 
 	[[ -d "$tmpdir/.claude/sessions" ]]
 }

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -10,12 +10,21 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
+	gum() { :; }
+	gh() { echo ""; }
+	git() { echo ""; }
+	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }
+	claude() { :; }
+	export -f gum gh git uuid claude
+
 	# shellcheck disable=SC2155
 	eval "$(
 		export _gh_ai_source_dir="$REPO_ROOT"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _split_on_separator
+		declare -f _split_on_separator \
+			_get_repo_name _get_git_repo_path _init_claude_session \
+			_git_worktree_sync _cmd_chat
 	)"
 }
 
@@ -100,4 +109,351 @@ setup() {
 
 	[[ ${#before[@]} -eq 0 ]]
 	[[ ${#after[@]} -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _get_repo_name
+# ---------------------------------------------------------------------------
+
+@test "_get_repo_name: sets nameref when gh repo view succeeds" {
+	gh() { echo "owner/repo"; }
+	export -f gh
+
+	local repo=""
+	_get_repo_name repo
+
+	[[ "$repo" == "owner/repo" ]]
+}
+
+@test "_get_repo_name: returns error when gh repo view returns empty" {
+	gh() { :; }
+	export -f gh
+
+	local repo=""
+	run _get_repo_name repo
+
+	[[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _get_git_repo_path
+# ---------------------------------------------------------------------------
+
+@test "_get_git_repo_path: sets nameref when git rev-parse succeeds" {
+	git() { echo "/home/user/myrepo"; }
+	export -f git
+
+	local dir=""
+	_get_git_repo_path dir
+
+	[[ "$dir" == "/home/user/myrepo" ]]
+}
+
+@test "_get_git_repo_path: returns error when git rev-parse returns empty" {
+	git() { :; }
+	export -f git
+
+	local dir=""
+	run _get_git_repo_path dir
+
+	[[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _init_claude_session
+# ---------------------------------------------------------------------------
+
+@test "_init_claude_session: populates session ID and file path" {
+	uuid() { echo "deadbeef-dead-beef-dead-beefdeadbeef"; }
+	export -f uuid
+
+	local tmpdir="$BATS_TMPDIR/init-session-test-$$"
+	local id="" file=""
+	_init_claude_session id file "owner/repo" "I42" "$tmpdir"
+
+	[[ "$id" == "deadbeef-dead-beef-dead-beefdeadbeef" ]]
+	[[ "$file" == "$tmpdir/.claude/sessions/deadbeef-dead-beef-dead-beefdeadbeef" ]]
+}
+
+@test "_init_claude_session: creates session directory" {
+	uuid() { echo "deadbeef-dead-beef-dead-beefdeadbeef"; }
+	export -f uuid
+
+	local tmpdir="$BATS_TMPDIR/init-session-mkdir-test-$$"
+	local id="" file=""
+	_init_claude_session id file "owner/repo" "P99" "$tmpdir"
+
+	[[ -d "$tmpdir/.claude/sessions" ]]
+}
+
+# ---------------------------------------------------------------------------
+# _git_worktree_sync
+# ---------------------------------------------------------------------------
+
+@test "_git_worktree_sync: creates worktree when path does not exist" {
+	local tmpdir="$BATS_TMPDIR/sync-wt-create-test-$$"
+	mkdir -p "$tmpdir"
+
+	local fetch_called=false
+	local worktree_called=false
+
+	git() {
+		case "$1 $2" in
+		"fetch origin") fetch_called=true ;;
+		"worktree add") worktree_called=true; mkdir -p "$4" ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@" || true
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+
+	_git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch" "PR #99"
+
+	[[ "$fetch_called" == true ]]
+	[[ "$worktree_called" == true ]]
+}
+
+@test "_git_worktree_sync: fast-forwards existing worktree" {
+	local tmpdir="$BATS_TMPDIR/sync-wt-ff-test-$$"
+	mkdir -p "$tmpdir/pr-99"
+
+	local merge_called=false
+
+	git() {
+		case "$1" in
+		-C) merge_called=true ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@" || true
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+
+	_git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch" "PR #99"
+
+	[[ "$merge_called" == true ]]
+}
+
+@test "_git_worktree_sync: returns error when merge is not fast-forward" {
+	local tmpdir="$BATS_TMPDIR/sync-wt-diverged-test-$$"
+	mkdir -p "$tmpdir/pr-99"
+
+	git() {
+		case "$1" in
+		-C) return 1 ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	# Do NOT swallow errors with || true so the || { return 1; } block in
+	# _git_worktree_sync fires when git merge --ff-only fails.
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@"
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+
+	run _git_worktree_sync "pr-99" "$tmpdir/pr-99" "feature/branch" "PR #99"
+
+	[[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _cmd_chat
+# ---------------------------------------------------------------------------
+
+@test "_cmd_chat: starts new session when sentinel file is absent" {
+	local tmpdir="$BATS_TMPDIR/chat-run-new-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-abc"
+
+	# claude runs on the right side of a pipe (subshell) — use a file to
+	# capture the --session-id value instead of an in-process variable.
+	export _claude_out="$tmpdir/claude-session-id"
+	claude() {
+		local prev=""
+		for arg in "$@"; do
+			if [[ "$prev" == "--session-id" ]]; then
+				echo "$arg" >"$_claude_out"
+			fi
+			prev="$arg"
+		done
+	}
+	export -f claude
+
+	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+		echo "plan content"
+
+	[[ "$(cat "$_claude_out")" == "test-uuid" ]]
+	[[ -f "$session_file" ]]
+}
+
+@test "_cmd_chat: touches sentinel file after successful new session" {
+	local tmpdir="$BATS_TMPDIR/chat-run-touch-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-xyz"
+
+	claude() { :; }
+	export -f claude
+
+	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+		echo "plan content"
+
+	[[ -f "$session_file" ]]
+}
+
+@test "_cmd_chat: resumes session when sentinel file exists" {
+	local tmpdir="$BATS_TMPDIR/chat-run-resume-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-abc"
+	touch "$session_file"
+
+	local resume_id=""
+	claude() {
+		for arg in "$@"; do
+			if [[ "$prev" == "--resume" ]]; then
+				resume_id="$arg"
+			fi
+			prev="$arg"
+		done
+	}
+	export -f claude
+
+	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+		echo "plan content"
+
+	[[ "$resume_id" == "test-uuid" ]]
+}
+
+@test "_cmd_chat: passes system prompt when provided" {
+	local tmpdir="$BATS_TMPDIR/chat-run-sysprompt-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-abc"
+
+	# Same subshell issue — capture via file.
+	export _claude_out="$tmpdir/claude-sysprompt"
+	claude() {
+		local prev=""
+		for arg in "$@"; do
+			if [[ "$prev" == "--append-system-prompt" ]]; then
+				echo "$arg" >"$_claude_out"
+			fi
+			prev="$arg"
+		done
+	}
+	export -f claude
+
+	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "Do not modify code." "" \
+		echo "plan"
+
+	[[ "$(cat "$_claude_out")" == "Do not modify code." ]]
+}
+
+@test "_cmd_chat: omits system prompt flag when prompt is empty" {
+	local tmpdir="$BATS_TMPDIR/chat-run-noprompt-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-abc"
+
+	local saw_append=false
+	claude() {
+		for arg in "$@"; do
+			if [[ "$arg" == "--append-system-prompt" ]]; then
+				saw_append=true
+			fi
+		done
+	}
+	export -f claude
+
+	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" \
+		echo "plan"
+
+	[[ "$saw_append" == false ]]
+}
+
+@test "_cmd_chat: errors when provider is not supported" {
+	local tmpdir="$BATS_TMPDIR/chat-provider-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-abc"
+
+	gh() {
+		case "$1 $2" in
+		"config get") echo "openai" ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	run _cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" echo "plan"
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_cmd_chat: passes --model when model arg is non-empty" {
+	local tmpdir="$BATS_TMPDIR/chat-model-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-abc"
+
+	export _claude_out="$tmpdir/claude-model"
+	claude() {
+		local prev=""
+		for arg in "$@"; do
+			if [[ "$prev" == "--model" ]]; then
+				echo "$arg" >"$_claude_out"
+			fi
+			prev="$arg"
+		done
+	}
+	export -f claude
+
+	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "claude-opus-4-5" echo "plan"
+
+	[[ "$(cat "$_claude_out")" == "claude-opus-4-5" ]]
+}
+
+@test "_cmd_chat: omits --model when no model is configured" {
+	local tmpdir="$BATS_TMPDIR/chat-no-model-test-$$"
+	mkdir -p "$tmpdir/wt"
+	local session_file="$tmpdir/session-abc"
+
+	local saw_model=false
+	claude() {
+		for arg in "$@"; do
+			if [[ "$arg" == "--model" ]]; then
+				saw_model=true
+			fi
+		done
+	}
+	export -f claude
+
+	_cmd_chat "$session_file" "$tmpdir/wt" "test-uuid" "" "" echo "plan"
+
+	[[ "$saw_model" == false ]]
 }

--- a/tests/gh_commit.bats
+++ b/tests/gh_commit.bats
@@ -11,7 +11,7 @@ setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
 	# Mock external commands not under test
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	export -f gum gh git

--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -25,7 +25,7 @@ setup() {
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _parse_issue_chat_args _show_issue_chat_help _gh_issue_chat \
-			_get_repo_name _get_git_repo_path _init_claude_session \
+			_get_repo_name _get_git_repo_path _init_chat_session \
 			_git_worktree_sync _cmd_chat _cmd_render
 	)"
 }

--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -26,7 +26,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _parse_issue_chat_args _show_issue_chat_help _gh_issue_chat \
 			_get_repo_name _get_git_repo_path _init_claude_session \
-			_git_worktree_sync _cmd_chat
+			_git_worktree_sync _cmd_chat _cmd_render
 	)"
 }
 
@@ -129,7 +129,7 @@ _setup_issue_chat_mocks() {
 			[[ $# -gt 0 ]] && shift
 			"$@" || true
 			;;
-		log) ;;
+		log) shift; echo "$@" ;;
 		esac
 	}
 	export -f gum
@@ -201,6 +201,49 @@ _setup_issue_chat_mocks() {
 	run _gh_issue_chat 42
 
 	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_issue_chat: errors when worktree creation fails" {
+	_setup_issue_chat_mocks
+
+	# Override git so worktree add does not create the directory
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$_test_git_dir" ;;
+		"fetch origin") return 1 ;;
+		"worktree add") return 1 ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gh() {
+		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
+		"issue develop") return 1 ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	run _gh_issue_chat 42
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"Failed to create worktree"* ]]
+}
+
+@test "_gh_issue_chat: errors when preamble rendering fails" {
+	_setup_issue_chat_mocks
+
+	# Pre-create worktree so we skip worktree setup
+	mkdir -p "$_test_git_dir/.claude/worktrees/issue-42"
+
+	_cmd_render() { :; }
+
+	run _gh_issue_chat 42
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"Failed to render chat preamble"* ]]
 }
 
 @test "_gh_issue_chat: shows help with --help flag" {

--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }

--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh ai issue chat arg parsing and integration
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_issue_chat.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+
+	gum() { :; }
+	gh() { echo ""; }
+	git() { echo ""; }
+	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }
+	claude() { :; }
+	export -f gum gh git uuid claude
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_issue.sh
+		source "$REPO_ROOT/scripts/gh_issue.sh"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		declare -f _parse_issue_chat_args _show_issue_chat_help _gh_issue_chat \
+			_get_repo_name _get_git_repo_path _init_claude_session \
+			_git_worktree_sync _cmd_chat
+	)"
+}
+
+# ---------------------------------------------------------------------------
+# _parse_issue_chat_args
+# ---------------------------------------------------------------------------
+
+@test "_parse_issue_chat_args: captures issue number from positional arg" {
+	local number=""
+	_parse_issue_chat_args number 42
+
+	[[ "$number" == "42" ]]
+}
+
+@test "_parse_issue_chat_args: strips leading # from issue number" {
+	local number=""
+	_parse_issue_chat_args number "#42"
+
+	[[ "$number" == "42" ]]
+}
+
+@test "_parse_issue_chat_args: defaults to empty when no args given" {
+	local number=""
+	_parse_issue_chat_args number
+
+	[[ -z "$number" ]]
+}
+
+@test "_parse_issue_chat_args: stops at -- separator" {
+	local number=""
+	_parse_issue_chat_args number 42 -- --extra-flag
+
+	[[ "$number" == "42" ]]
+}
+
+@test "_parse_issue_chat_args: returns error for unknown flags" {
+	local number=""
+	run _parse_issue_chat_args number --draft
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unknown flag '--draft'"* ]]
+}
+
+@test "_parse_issue_chat_args: returns error for unexpected non-numeric arg" {
+	local number=""
+	run _parse_issue_chat_args number foo
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument 'foo'"* ]]
+}
+
+@test "_parse_issue_chat_args: returns error for second positional arg" {
+	local number=""
+	run _parse_issue_chat_args number 42 99
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument '99'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# _gh_issue_chat integration
+# ---------------------------------------------------------------------------
+
+# Sets up mocks for a successful _gh_issue_chat run.
+# Callers can override individual functions after calling this.
+_setup_issue_chat_mocks() {
+	export _test_git_dir="$BATS_TMPDIR/gh-ai-test-$$"
+	mkdir -p "$_test_git_dir/.claude/sessions"
+
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$_test_git_dir" ;;
+		"fetch origin") ;;
+		"worktree add") mkdir -p "$_test_git_dir/.claude/worktrees/issue-42" ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gh() {
+		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
+		"issue develop") ;;
+		"ai issue") echo "# Implementation Plan" ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }
+	export -f uuid
+
+	claude() { :; }
+	export -f claude
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@" || true
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+}
+
+@test "_gh_issue_chat: errors when no issue number provided" {
+	_setup_issue_chat_mocks
+
+	run _gh_issue_chat
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_issue_chat: errors when repo resolution fails" {
+	_setup_issue_chat_mocks
+
+	gh() {
+		case "$1 $2" in
+		"repo view") ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	run _gh_issue_chat 42
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_issue_chat: errors when git root resolution fails" {
+	_setup_issue_chat_mocks
+
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	run _gh_issue_chat 42
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_issue_chat: creates worktree and starts session when sentinel absent" {
+	_setup_issue_chat_mocks
+
+	claude() { :; }
+	export -f claude
+
+	run _gh_issue_chat 42
+
+	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_issue_chat: resumes session when sentinel file exists" {
+	_setup_issue_chat_mocks
+
+	# Pre-create the worktree dir and session sentinel
+	mkdir -p "$_test_git_dir/.claude/worktrees/issue-42"
+	local session_id
+	session_id="aaaabbbb-1234-5678-abcd-ef0123456789"
+	touch "$_test_git_dir/.claude/sessions/$session_id"
+
+	claude() { :; }
+	export -f claude
+
+	run _gh_issue_chat 42
+
+	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_issue_chat: shows help with --help flag" {
+	run _gh_issue_chat --help
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"gh ai issue chat"* ]]
+}

--- a/tests/gh_issue_create.bats
+++ b/tests/gh_issue_create.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	export -f gum gh git

--- a/tests/gh_issue_edit.bats
+++ b/tests/gh_issue_edit.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	export -f gum gh git

--- a/tests/gh_issue_plan.bats
+++ b/tests/gh_issue_plan.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	export -f gum gh
 

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -26,7 +26,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _parse_pr_chat_args _show_pr_chat_help _gh_pr_chat \
 			_get_repo_name _get_git_repo_path _init_claude_session \
-			_git_worktree_sync _cmd_chat
+			_git_worktree_sync _cmd_chat _cmd_render
 	)"
 }
 
@@ -128,7 +128,7 @@ _setup_pr_chat_mocks() {
 			[[ $# -gt 0 ]] && shift
 			"$@" || true
 			;;
-		log) ;;
+		log) shift; echo "$@" ;;
 		esac
 	}
 	export -f gum
@@ -197,6 +197,20 @@ _setup_pr_chat_mocks() {
 	run _gh_pr_chat 99
 
 	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_pr_chat: errors when preamble rendering fails" {
+	_setup_pr_chat_mocks
+
+	# Pre-create worktree so we skip worktree setup
+	mkdir -p "$_test_git_dir/.claude/worktrees/pr-99"
+
+	_cmd_render() { :; }
+
+	run _gh_pr_chat 99
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"Failed to render chat preamble"* ]]
 }
 
 @test "_gh_pr_chat: shows help with --help flag" {

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -25,7 +25,7 @@ setup() {
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _parse_pr_chat_args _show_pr_chat_help _gh_pr_chat \
-			_get_repo_name _get_git_repo_path _init_claude_session \
+			_get_repo_name _get_git_repo_path _init_chat_session \
 			_git_worktree_sync _cmd_chat _cmd_render
 	)"
 }

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh ai pr chat arg parsing and integration
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_pr_chat.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+
+	gum() { :; }
+	gh() { echo ""; }
+	git() { echo ""; }
+	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }
+	claude() { :; }
+	export -f gum gh git uuid claude
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_pr.sh
+		source "$REPO_ROOT/scripts/gh_pr.sh"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		declare -f _parse_pr_chat_args _show_pr_chat_help _gh_pr_chat \
+			_get_repo_name _get_git_repo_path _init_claude_session \
+			_git_worktree_sync _cmd_chat
+	)"
+}
+
+# ---------------------------------------------------------------------------
+# _parse_pr_chat_args
+# ---------------------------------------------------------------------------
+
+@test "_parse_pr_chat_args: captures PR number from positional arg" {
+	local number=""
+	_parse_pr_chat_args number 99
+
+	[[ "$number" == "99" ]]
+}
+
+@test "_parse_pr_chat_args: strips leading # from PR number" {
+	local number=""
+	_parse_pr_chat_args number "#99"
+
+	[[ "$number" == "99" ]]
+}
+
+@test "_parse_pr_chat_args: defaults to empty when no args given" {
+	local number=""
+	_parse_pr_chat_args number
+
+	[[ -z "$number" ]]
+}
+
+@test "_parse_pr_chat_args: stops at -- separator" {
+	local number=""
+	_parse_pr_chat_args number 99 -- --extra-flag
+
+	[[ "$number" == "99" ]]
+}
+
+@test "_parse_pr_chat_args: returns error for unknown flags" {
+	local number=""
+	run _parse_pr_chat_args number --comment
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unknown flag '--comment'"* ]]
+}
+
+@test "_parse_pr_chat_args: returns error for unexpected non-numeric arg" {
+	local number=""
+	run _parse_pr_chat_args number foo
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument 'foo'"* ]]
+}
+
+@test "_parse_pr_chat_args: returns error for second positional arg" {
+	local number=""
+	run _parse_pr_chat_args number 99 100
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument '100'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# _gh_pr_chat integration
+# ---------------------------------------------------------------------------
+
+# Sets up mocks for a successful _gh_pr_chat run.
+_setup_pr_chat_mocks() {
+	export _test_git_dir="$BATS_TMPDIR/gh-ai-pr-test-$$"
+	mkdir -p "$_test_git_dir/.claude/sessions"
+
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$_test_git_dir" ;;
+		"fetch origin") ;;
+		"worktree add") mkdir -p "$_test_git_dir/.claude/worktrees/pr-99" ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gh() {
+		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
+		"pr view") echo "feature/my-branch" ;;
+		"ai pr") echo "# PR Explanation" ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }
+	export -f uuid
+
+	claude() { :; }
+	export -f claude
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@" || true
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+}
+
+@test "_gh_pr_chat: errors when no PR number provided" {
+	_setup_pr_chat_mocks
+
+	run _gh_pr_chat
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_pr_chat: errors when repo resolution fails" {
+	_setup_pr_chat_mocks
+
+	gh() {
+		case "$1 $2" in
+		"repo view") ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	run _gh_pr_chat 99
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_pr_chat: errors when PR head branch fetch fails" {
+	_setup_pr_chat_mocks
+
+	gh() {
+		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
+		"pr view") ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	run _gh_pr_chat 99
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_pr_chat: creates worktree and starts session when sentinel absent" {
+	_setup_pr_chat_mocks
+
+	run _gh_pr_chat 99
+
+	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_pr_chat: resumes session when sentinel file exists" {
+	_setup_pr_chat_mocks
+
+	# Pre-create the worktree dir and session sentinel
+	mkdir -p "$_test_git_dir/.claude/worktrees/pr-99"
+	local session_id="aaaabbbb-1234-5678-abcd-ef0123456789"
+	touch "$_test_git_dir/.claude/sessions/$session_id"
+
+	claude() { :; }
+	export -f claude
+
+	run _gh_pr_chat 99
+
+	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_pr_chat: shows help with --help flag" {
+	run _gh_pr_chat --help
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"gh ai pr chat"* ]]
+	[[ "$output" == *"discussion"* ]]
+}

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }

--- a/tests/gh_pr_create.bats
+++ b/tests/gh_pr_create.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	export -f gum gh git

--- a/tests/gh_pr_edit.bats
+++ b/tests/gh_pr_edit.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	export -f gum gh git

--- a/tests/gh_pr_explain.bats
+++ b/tests/gh_pr_explain.bats
@@ -1,0 +1,223 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh ai pr explain arg parsing and integration
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_pr_explain.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
+	gh() { echo ""; }
+	git() { echo ""; }
+	export -f gum gh git
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		# shellcheck source=../scripts/gh_pr.sh
+		source "$REPO_ROOT/scripts/gh_pr.sh"
+		declare -f _parse_pr_explain_args _show_pr_explain_help _gh_pr_explain _cmd_render _cmd_assist
+	)"
+}
+
+# ---------------------------------------------------------------------------
+# _parse_pr_explain_args
+# ---------------------------------------------------------------------------
+
+@test "_parse_pr_explain_args: captures PR number from positional arg" {
+	local number="" mode=""
+	_parse_pr_explain_args number mode 42
+
+	[[ "$number" == "42" ]]
+	[[ -z "$mode" ]]
+}
+
+@test "_parse_pr_explain_args: strips leading # from PR number" {
+	local number="" mode=""
+	_parse_pr_explain_args number mode "#42"
+
+	[[ "$number" == "42" ]]
+}
+
+@test "_parse_pr_explain_args: sets comment mode from --comment flag" {
+	local number="" mode=""
+	_parse_pr_explain_args number mode 42 --comment
+
+	[[ "$number" == "42" ]]
+	[[ "$mode" == "comment" ]]
+}
+
+@test "_parse_pr_explain_args: sets edit mode from --edit flag" {
+	local number="" mode=""
+	_parse_pr_explain_args number mode 42 --edit
+
+	[[ "$number" == "42" ]]
+	[[ "$mode" == "edit" ]]
+}
+
+@test "_parse_pr_explain_args: defaults to empty mode when no flags given" {
+	local number="" mode=""
+	_parse_pr_explain_args number mode 42
+
+	[[ -z "$mode" ]]
+}
+
+@test "_parse_pr_explain_args: returns error for unknown flags" {
+	local number="" mode=""
+	run _parse_pr_explain_args number mode --draft
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unknown flag '--draft'"* ]]
+}
+
+@test "_parse_pr_explain_args: returns error for unexpected non-numeric arg" {
+	local number="" mode=""
+	run _parse_pr_explain_args number mode foo
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument 'foo'"* ]]
+}
+
+@test "_parse_pr_explain_args: returns error for second positional arg" {
+	local number="" mode=""
+	run _parse_pr_explain_args number mode 42 99
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument '99'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Helpers shared by _gh_pr_explain integration tests
+# ---------------------------------------------------------------------------
+
+_setup_explain_mocks() {
+	gh() {
+		case "$1 $2" in
+		"pr diff") echo "diff --git a/file.txt b/file.txt" ;;
+		"pr view") echo "Test PR Title" ;;
+		"config get") ;;
+		esac
+	}
+	export -f gh
+
+	git() {
+		case "$1 $2" in
+		"apply --stat") echo " file.txt | 1 +" ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			case "${1:-}" in
+			*/gh_cmd.sh) printf '## Summary\n\nThis PR does things.\n\n## What Changed\n\n- Changed stuff\n' ;;
+			*) "$@" ;;
+			esac
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+}
+
+@test "_gh_pr_explain: prints explanation to stdout" {
+	_setup_explain_mocks
+
+	run _gh_pr_explain 42
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"Summary"* ]]
+	[[ "$output" == *"Changed stuff"* ]]
+}
+
+@test "_gh_pr_explain: errors when no PR number provided" {
+	_setup_explain_mocks
+
+	# Override gh to return empty for auto-detect
+	gh() {
+		case "$1 $2" in
+		"pr view") ;;
+		"config get") ;;
+		esac
+	}
+	export -f gh
+
+	run _gh_pr_explain
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_pr_explain: errors when diff is empty" {
+	gh() {
+		case "$1 $2" in
+		"pr diff") ;;
+		"pr view") echo "Test PR Title" ;;
+		"config get") ;;
+		esac
+	}
+	export -f gh
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@"
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+
+	run _gh_pr_explain 42
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_pr_explain: errors when AI output is empty" {
+	gh() {
+		case "$1 $2" in
+		"pr diff") echo "diff --git a/file.txt b/file.txt" ;;
+		"pr view") echo "Test PR Title" ;;
+		"config get") ;;
+		esac
+	}
+	export -f gh
+
+	git() {
+		case "$1 $2" in
+		"apply --stat") echo " file.txt | 1 +" ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			case "${1:-}" in
+			*/gh_cmd.sh) ;;
+			*) "$@" ;;
+			esac
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+
+	run _gh_pr_explain 42
+
+	[[ "$status" -eq 1 ]]
+}

--- a/tests/gh_pr_review.bats
+++ b/tests/gh_pr_review.bats
@@ -11,7 +11,7 @@ setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
 	# Mock external commands not under test
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	export -f gum gh git

--- a/tests/gh_run_chat.bats
+++ b/tests/gh_run_chat.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh ai run chat arg parsing and integration
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_run_chat.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+
+	gum() { :; }
+	gh() { echo ""; }
+	git() { echo ""; }
+	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }
+	claude() { :; }
+	export -f gum gh git uuid claude
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_run.sh
+		source "$REPO_ROOT/scripts/gh_run.sh"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		declare -f _parse_run_chat_args _show_run_chat_help _gh_run_chat \
+			_get_repo_name _get_git_repo_path _init_claude_session \
+			_git_worktree_sync _cmd_chat
+	)"
+}
+
+# ---------------------------------------------------------------------------
+# _parse_run_chat_args
+# ---------------------------------------------------------------------------
+
+@test "_parse_run_chat_args: captures run ID from positional arg" {
+	local id=""
+	_parse_run_chat_args id 12345678
+
+	[[ "$id" == "12345678" ]]
+}
+
+@test "_parse_run_chat_args: strips leading # from run ID" {
+	local id=""
+	_parse_run_chat_args id "#12345678"
+
+	[[ "$id" == "12345678" ]]
+}
+
+@test "_parse_run_chat_args: defaults to empty when no args given" {
+	local id=""
+	_parse_run_chat_args id
+
+	[[ -z "$id" ]]
+}
+
+@test "_parse_run_chat_args: stops at -- separator" {
+	local id=""
+	_parse_run_chat_args id 12345678 -- --extra-flag
+
+	[[ "$id" == "12345678" ]]
+}
+
+@test "_parse_run_chat_args: returns error for unknown flags" {
+	local id=""
+	run _parse_run_chat_args id --failed
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unknown flag '--failed'"* ]]
+}
+
+@test "_parse_run_chat_args: returns error for unexpected non-numeric arg" {
+	local id=""
+	run _parse_run_chat_args id foo
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument 'foo'"* ]]
+}
+
+@test "_parse_run_chat_args: returns error for second positional arg" {
+	local id=""
+	run _parse_run_chat_args id 12345678 99999999
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument '99999999'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# _gh_run_chat integration
+# ---------------------------------------------------------------------------
+
+# Sets up mocks for a successful _gh_run_chat run.
+_setup_run_chat_mocks() {
+	export _test_git_dir="$BATS_TMPDIR/gh-ai-run-test-$$"
+	mkdir -p "$_test_git_dir/.claude/sessions"
+
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$_test_git_dir" ;;
+		"fetch origin") ;;
+		"worktree add") mkdir -p "$_test_git_dir/.claude/worktrees/run-12345678" ;;
+		*) ;;
+		esac
+	}
+	export -f git
+
+	gh() {
+		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
+		"run view") echo "main" ;;
+		"ai run") echo "# Run Explanation" ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }
+	export -f uuid
+
+	claude() { :; }
+	export -f claude
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@" || true
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+}
+
+@test "_gh_run_chat: errors when no run ID provided" {
+	_setup_run_chat_mocks
+
+	run _gh_run_chat
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_run_chat: errors when repo resolution fails" {
+	_setup_run_chat_mocks
+
+	gh() {
+		case "$1 $2" in
+		"repo view") ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	run _gh_run_chat 12345678
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_run_chat: errors when run head branch fetch fails" {
+	_setup_run_chat_mocks
+
+	gh() {
+		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
+		"run view") ;;
+		*) ;;
+		esac
+	}
+	export -f gh
+
+	run _gh_run_chat 12345678
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_run_chat: creates worktree and starts session when sentinel absent" {
+	_setup_run_chat_mocks
+
+	run _gh_run_chat 12345678
+
+	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_run_chat: resumes session when sentinel file exists" {
+	_setup_run_chat_mocks
+
+	# Pre-create the worktree dir and session sentinel
+	mkdir -p "$_test_git_dir/.claude/worktrees/run-12345678"
+	local session_id="aaaabbbb-1234-5678-abcd-ef0123456789"
+	touch "$_test_git_dir/.claude/sessions/$session_id"
+
+	claude() { :; }
+	export -f claude
+
+	run _gh_run_chat 12345678
+
+	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_run_chat: shows help with --help flag" {
+	run _gh_run_chat --help
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"gh ai run chat"* ]]
+	[[ "$output" == *"debug"* ]]
+}

--- a/tests/gh_run_chat.bats
+++ b/tests/gh_run_chat.bats
@@ -25,7 +25,7 @@ setup() {
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _parse_run_chat_args _show_run_chat_help _gh_run_chat \
-			_get_repo_name _get_git_repo_path _init_claude_session \
+			_get_repo_name _get_git_repo_path _init_chat_session \
 			_git_worktree_sync _cmd_chat _cmd_render
 	)"
 }

--- a/tests/gh_run_chat.bats
+++ b/tests/gh_run_chat.bats
@@ -10,7 +10,7 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
 
-	gum() { :; }
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
 	uuid() { echo "aaaabbbb-1234-5678-abcd-ef0123456789"; }

--- a/tests/gh_run_chat.bats
+++ b/tests/gh_run_chat.bats
@@ -26,7 +26,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _parse_run_chat_args _show_run_chat_help _gh_run_chat \
 			_get_repo_name _get_git_repo_path _init_claude_session \
-			_git_worktree_sync _cmd_chat
+			_git_worktree_sync _cmd_chat _cmd_render
 	)"
 }
 
@@ -128,7 +128,7 @@ _setup_run_chat_mocks() {
 			[[ $# -gt 0 ]] && shift
 			"$@" || true
 			;;
-		log) ;;
+		log) shift; echo "$@" ;;
 		esac
 	}
 	export -f gum
@@ -197,6 +197,20 @@ _setup_run_chat_mocks() {
 	run _gh_run_chat 12345678
 
 	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_run_chat: errors when preamble rendering fails" {
+	_setup_run_chat_mocks
+
+	# Pre-create worktree so we skip worktree setup
+	mkdir -p "$_test_git_dir/.claude/worktrees/run-12345678"
+
+	_cmd_render() { :; }
+
+	run _gh_run_chat 12345678
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"Failed to render chat preamble"* ]]
 }
 
 @test "_gh_run_chat: shows help with --help flag" {

--- a/tests/gh_run_explain.bats
+++ b/tests/gh_run_explain.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh ai run explain arg parsing and integration
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_run_explain.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
+	gh() { echo ""; }
+	export -f gum gh
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_run.sh
+		source "$REPO_ROOT/scripts/gh_run.sh"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		declare -f _parse_run_explain_args _show_run_explain_help _gh_run_explain _cmd_render _cmd_assist
+	)"
+}
+
+# ---------------------------------------------------------------------------
+# _parse_run_explain_args
+# ---------------------------------------------------------------------------
+
+@test "_parse_run_explain_args: captures run ID from positional arg" {
+	local id=""
+	_parse_run_explain_args id 12345678
+
+	[[ "$id" == "12345678" ]]
+}
+
+@test "_parse_run_explain_args: strips leading # from run ID" {
+	local id=""
+	_parse_run_explain_args id "#12345678"
+
+	[[ "$id" == "12345678" ]]
+}
+
+@test "_parse_run_explain_args: defaults to empty when no args given" {
+	local id=""
+	_parse_run_explain_args id
+
+	[[ -z "$id" ]]
+}
+
+@test "_parse_run_explain_args: returns error for unknown flags" {
+	local id=""
+	run _parse_run_explain_args id --failed
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unknown flag '--failed'"* ]]
+}
+
+@test "_parse_run_explain_args: returns error for unexpected non-numeric arg" {
+	local id=""
+	run _parse_run_explain_args id foo
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument 'foo'"* ]]
+}
+
+@test "_parse_run_explain_args: returns error for second positional arg" {
+	local id=""
+	run _parse_run_explain_args id 12345678 99999999
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"unexpected argument '99999999'"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Helpers shared by _gh_run_explain integration tests
+# ---------------------------------------------------------------------------
+
+_setup_explain_mocks() {
+	gh() {
+		case "$1 $2" in
+		"run view") printf "gh_run_title='Test Run'\ngh_run_conclusion='failure'\ngh_run_url='https://github.com/owner/repo/actions/runs/123'\ngh_run_event='push'\ngh_run_branch='main'\ngh_run_jobs='build'" ;;
+		"config get") ;;
+		esac
+	}
+	export -f gh
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			case "${1:-}" in
+			*/gh_cmd.sh) printf '## Root Cause\n\nTest failure in build step.\n\n## Fix\n\n- Fix the test\n' ;;
+			*) "$@" ;;
+			esac
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+}
+
+@test "_gh_run_explain: prints explanation to stdout" {
+	_setup_explain_mocks
+
+	run _gh_run_explain 12345678
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"Root Cause"* ]]
+	[[ "$output" == *"Fix the test"* ]]
+}
+
+@test "_gh_run_explain: errors when no run ID provided" {
+	_setup_explain_mocks
+
+	run _gh_run_explain
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_run_explain: errors when metadata fetch fails" {
+	gh() {
+		case "$1 $2" in
+		"run view") ;;
+		"config get") ;;
+		esac
+	}
+	export -f gh
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			"$@"
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+
+	run _gh_run_explain 12345678
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_run_explain: errors when AI output is empty" {
+	gh() {
+		case "$1 $2" in
+		"run view") printf "gh_run_title='Test Run'\ngh_run_conclusion='failure'\ngh_run_url='https://github.com/owner/repo/actions/runs/123'\ngh_run_event='push'\ngh_run_branch='main'\ngh_run_jobs='build'" ;;
+		"config get") ;;
+		esac
+	}
+	export -f gh
+
+	gum() {
+		case "$1" in
+		spin)
+			while [[ $# -gt 0 && "$1" != "--" ]]; do shift; done
+			[[ $# -gt 0 ]] && shift
+			case "${1:-}" in
+			*/gh_cmd.sh) ;;
+			*) "$@" ;;
+			esac
+			;;
+		log) ;;
+		esac
+	}
+	export -f gum
+
+	run _gh_run_explain 12345678
+
+	[[ "$status" -eq 1 ]]
+}


### PR DESCRIPTION

## Summary

Adds a `chat` subcommand to `gh ai issue`, `gh ai pr`, and `gh ai run` that opens an interactive Claude Code session in an isolated git worktree. Each session is seeded with context from the corresponding `plan`/`explain` command and uses a deterministic UUID v5 session ID so re-running the same command resumes the previous conversation. The `gh-fzf` integration file is renamed from `gh_fzf_ai.sh` to `gh_fzf.sh` and gains tmux-gated keybinds for the new chat commands.

## Risk Level

**Medium** — introduces new shell functions that shell out to `claude`, `git worktree`, and `uuid`, but all mutations
are confined to `.claude/worktrees/` and `.claude/sessions/` under the repo root. Existing commands are unchanged.

## Changes

### Behavior & Execution Flow

Each `chat` subcommand follows the same lifecycle:

1. Resolve repo name (`_get_repo_name`) and git root (`_get_git_repo_path`).
2. Derive a deterministic UUID v5 session ID via `uuid -v5 ns:URL "<owner/repo>#<entity_key>"` and prepare a sentinel file under `.claude/sessions/` (`_init_claude_session`).
3. Create or sync a git worktree under `.claude/worktrees/<branch>` (`_git_worktree_sync` for PR/run;
   `gh issue develop` + `git worktree add` fallback for issues).
4. If the sentinel file exists, resume the Claude session (`claude --resume`). Otherwise, pipe the seed command
   (`gh ai issue plan`, `gh ai pr explain`, or `gh ai run explain`) into `claude --session-id` and touch the sentinel on
   success (`_cmd_chat`).

The core orchestration lives in four new shared helpers in `scripts/gh_cmd.sh`:

| Helper                 | Purpose                                                         |
| ---------------------- | --------------------------------------------------------------- |
| `_get_repo_name`       | Resolves `owner/repo` via `gh repo view`                        |
| `_get_git_repo_path`   | Resolves the git toplevel directory                             |
| `_init_claude_session` | Derives UUID v5 session ID, creates session directory           |
| `_git_worktree_sync`   | Creates or fast-forwards a worktree from a remote branch        |
| `_cmd_chat`            | Starts or resumes a Claude Code session with provider detection |

### Design Decisions

- **Deterministic session IDs** — UUID v5 keyed on `<repo>#<entity>` means the same issue/PR/run always maps to the same
  session, enabling seamless resume without state files beyond a lightweight sentinel.
- **Sentinel file pattern** — a zero-byte file at `.claude/sessions/<uuid>` distinguishes "never started" from
  "started at least once". This avoids parsing Claude's internal state.
- **Worktree isolation** — all worktrees live under `.claude/worktrees/` in the repo root, keeping them out of the
  main working tree and easy to `.gitignore`.
- **Issue worktree creation** differs from PR/run: issues may not have a remote branch yet, so the flow tries
  `git fetch`, falls back to `gh issue develop`, then falls back to a detached local branch
  (`gh_issue.sh:509-514`).
- **`_cmd_assist` / `_cmd_chat` exit → return** — changed `exit 1` to `return 1` in the unsupported-provider branch
  (`gh_cmd.sh:70`, `gh_cmd.sh:116`) so callers can handle the error without terminating the process.
- **`gh_fzf_ai.sh` → `gh_fzf.sh`** — the old name implied AI-only scope; the new name is shorter and matches the
  extension it integrates with. New `alt-D`/`alt-R` bindings are tmux-gated to avoid errors in non-tmux terminals.

### Edge Cases

- **No issue number / PR number / run ID** — each parser returns an error with a usage hint.
- **Leading `#` on identifiers** — stripped before validation (`${arg#\#}`).
- **Duplicate positional args** — second numeric arg triggers `"unexpected argument"` error.
- **Unsupported provider** — `_cmd_chat` returns 1 with a `gum log` error instead of silently failing.
- **Worktree divergence** — `_git_worktree_sync` detects non-fast-forward merges and returns 1 with an actionable error
  message rather than silently overwriting local changes.
- **Missing `claude` or `uuid` binary** — will fail at invocation time with the shell's standard "command not found";
  `ossp-uuid` is now included in the Nix dev shell (`flake.nix`).

## Testing

Three new test files with comprehensive coverage:

| File                       | Tests                                                                                                              |
| -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| `tests/gh_cmd.bats`        | 17 new tests for `_get_repo_name`, `_get_git_repo_path`, `_init_claude_session`, `_git_worktree_sync`, `_cmd_chat` |
| `tests/gh_issue_chat.bats` | 14 tests — arg parsing (7) + integration (7)                                                                       |
| `tests/gh_pr_chat.bats`    | 13 tests — arg parsing (7) + integration (6)                                                                       |
| `tests/gh_run_chat.bats`   | 13 tests — arg parsing (7) + integration (6)                                                                       |

```bash
npx bats tests/
```

All external commands (`gh`, `git`, `claude`, `uuid`, `gum`) are mocked via exported functions. The `_cmd_chat` tests
use file-based capture for values observed inside pipeline subshells.

## Impact

- **Breaking Changes:** `extras/gh_fzf_ai.sh` is renamed to `extras/gh_fzf.sh` — users sourcing the old path must
  update their shell config.
- **Performance:** No change to existing commands; `chat` adds a one-time worktree setup cost.
- **Security:** Claude Code sessions run with the user's ambient credentials; no new auth surfaces are introduced. The
  `--append-system-prompt` constrains session behavior (e.g., PR chat is discussion-only, no commits).

<!-- markdownlint-disable-file MD013 MD022 MD041 MD047 -->
