### PR TITLE
feat: add persistent session management for chat commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude/worktrees/
+.claude/sessions/

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ gh ai pr create [-d <DESCRIPTION>] [-B <BASE>] [-- GH_PR_CREATE_OPTIONS]
 gh ai pr edit [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_EDIT_OPTIONS]
 gh ai pr review [PR_NUMBER] [-d <DESCRIPTION>] [-- GH_PR_REVIEW_OPTIONS]
 gh ai pr explain [PR_NUMBER] [--comment | --edit]
-gh ai pr chat [PR_NUMBER] [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+gh ai pr chat [PR_NUMBER] [-d <DESCRIPTION>] [--reset] [-- AGENT_OPTIONS]
 gh ai issue create -d <DESCRIPTION> [-- GH_ISSUE_CREATE_OPTIONS]
 gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [-- GH_ISSUE_EDIT_OPTIONS]
 gh ai issue plan <ISSUE_NUMBER> [-d <DESCRIPTION>]
-gh ai issue chat <ISSUE_NUMBER> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+gh ai issue chat <ISSUE_NUMBER> [-d <DESCRIPTION>] [--reset] [-- AGENT_OPTIONS]
 gh ai run explain <RUN_ID>
-gh ai run chat <RUN_ID> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+gh ai run chat <RUN_ID> [-d <DESCRIPTION>] [--reset] [-- AGENT_OPTIONS]
 ```
 
 ### Pull Request
@@ -75,11 +75,14 @@ gh ai pr explain 42 --comment    # post as PR comment
 gh ai pr explain 42 --edit       # replace PR description
 ```
 
-Opens an interactive agent session with PR context.
+Opens an interactive agent session with PR context. Sessions are persistent —
+running the same command again resumes the previous session. Use `--reset` to
+start fresh.
 
 ```bash
 gh ai pr chat 42
 gh ai pr chat -d "focus on the security changes"
+gh ai pr chat 42 --reset           # discard previous session
 gh ai pr chat 42 -- --model sonnet
 ```
 
@@ -128,11 +131,14 @@ gh issue develop 42 --checkout && \
   gh ai issue plan 42 | gh pr create --body -
 ```
 
-Opens an interactive agent session with issue context.
+Opens an interactive agent session with issue context. Sessions are persistent —
+running the same command again resumes the previous session. Use `--reset` to
+start fresh.
 
 ```bash
 gh ai issue chat 42
 gh ai issue chat 42 -d "focus on the auth module"
+gh ai issue chat 42 --reset           # discard previous session
 gh ai issue chat 42 -- --model sonnet
 ```
 
@@ -144,13 +150,30 @@ Analyzes a GitHub Actions workflow run and explains what happened.
 gh ai run explain 123456 # uses --log-failed for failed runs, --log otherwise
 ```
 
-Opens an interactive agent session with workflow run context.
+Opens an interactive agent session with workflow run context. Sessions are
+persistent — running the same command again resumes the previous session.
+Use `--reset` to start fresh.
 
 ```bash
 gh ai run chat 123456
 gh ai run chat 123456 -d "focus on test failures"
+gh ai run chat 123456 --reset           # discard previous session
 gh ai run chat 123456 -- --model sonnet
 ```
+
+## Session Management
+
+Chat commands automatically persist sessions per resource. The first
+invocation creates a new session with a dedicated worktree; subsequent runs
+resume it. Session state is stored in the repository at:
+
+```
+<repo-root>/.claude/sessions/<session-uuid>.json
+```
+
+Use `--reset` to discard the existing session and start fresh. Session
+management is skipped when you pass your own `--resume`, `--session-id`,
+`--continue`, or `-c` after `--`.
 
 ## Configuration
 

--- a/scripts/gh_claude.json
+++ b/scripts/gh_claude.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${_GH_AI_SOURCE_DIR}/scripts/gh_worktree.sh\" create"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${_GH_AI_SOURCE_DIR}/scripts/gh_worktree.sh\" remove"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # Safety: substitution is a single left-to-right pass — values are never
 # re-scanned, so ${...} patterns inside a substituted value (e.g. in a git
 # diff) are never expanded. Template files use ALL_CAPS variable names
-# (GIT_DIFF, GH_PR_*, etc.) that do not overlap with standard shell variables.
+# (GH_PR_DIFF, GH_ISSUE_*, etc.) that do not overlap with standard shell variables.
 #
 # Usage: MY_VAR="value" _cmd_render template.tmpl
 _cmd_render() {
@@ -70,6 +70,7 @@ _cmd_ask() {
 	claude)
 		MAX_THINKING_TOKENS=0 claude -p \
 			--model="$agent_model" \
+			--no-session-persistence \
 			--disable-slash-commands \
 			--setting-sources='' \
 			--system-prompt='' \
@@ -86,11 +87,14 @@ _cmd_ask() {
 # Pipe a preamble into the configured agent binary
 #
 # Resolves ai.agent (default: claude), verifies the binary exists, then
-# pipes the preamble into it. Extra positional args are forwarded to the agent.
+# pipes the preamble into it. Automatically injects --settings pointing to
+# the extension's scripts/gh_claude.json. Extra positional args are forwarded
+# to the agent.
 #
 # Usage: _cmd_chat "context preamble" [AGENT_ARGS...]
 _cmd_chat() {
-	local preamble="$1"; shift
+	local preamble="$1"
+	shift
 	local agent
 	agent=$(_get_agent)
 	if ! command -v "$agent" &>/dev/null; then
@@ -98,7 +102,10 @@ _cmd_chat() {
 		gum log --level info "Install it or set: gh config set ai.agent <binary>"
 		return 1
 	fi
-	printf '%s\n' "$preamble" | "$agent" "$@"
+	# shellcheck disable=SC2154
+	export _GH_AI_SOURCE_DIR="$_gh_ai_source_dir"
+	local settings_file="$_gh_ai_source_dir/scripts/gh_claude.json"
+	printf '%s\n' "$preamble" | "$agent" --settings "$settings_file" "$@"
 }
 
 # Extract title from AI response
@@ -106,9 +113,9 @@ _cmd_chat() {
 # Gets the title from AI-generated content by taking the first line
 # and removing any markdown heading prefix (#).
 #
-# Example: _get_title "# Fix bug in parser\n\nDescription..."
+# Example: _parse_title "# Fix bug in parser\n\nDescription..."
 # Returns: "Fix bug in parser"
-_get_title() {
+_parse_title() {
 	local content="$1"
 
 	local title
@@ -127,7 +134,7 @@ _get_title() {
 #
 # Takes everything after the first line of AI content (skipping the title),
 # removes leading blank lines, and prepends a markdownlint directive.
-_get_body() {
+_parse_body() {
 	local content="$1"
 
 	local body
@@ -171,8 +178,8 @@ _split_on_separator() {
 #
 # Writes the result into the nameref; returns 1 and logs an error on failure.
 #
-# Usage: _get_repo_name repo_ref
-_get_repo_name() {
+# Usage: _gh_repo_name repo_ref
+_gh_repo_name() {
 	local -n _gh_repo_ref="$1"
 	_gh_repo_ref=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)
 	if [[ -z "$_gh_repo_ref" ]]; then
@@ -185,13 +192,177 @@ _get_repo_name() {
 #
 # Writes the result into the nameref; returns 1 and logs an error on failure.
 #
-# Usage: _get_git_repo_path git_dir_ref
-_get_git_repo_path() {
+# Usage: _git_repo_path git_dir_ref
+_git_repo_path() {
 	local -n _git_dir_ref="$1"
 	_git_dir_ref=$(git rev-parse --show-toplevel 2>/dev/null || true)
 	if [[ -z "$_git_dir_ref" ]]; then
 		gum log --level error "Not inside a git repository"
 		return 1
+	fi
+}
+
+# Compute diff, diffstat, log, and formatted commits between two branches
+#
+# Tries origin/<base> first, falls back to bare <base>.
+# Writes results into four namerefs; returns 1 if the diff is empty.
+#
+# Usage: _git_branch_diff base head diff_ref stat_ref log_ref commits_ref
+_git_branch_diff() {
+	local base="$1" head="$2"
+	local -n _diff_ref="$3" _stat_ref="$4" _log_ref="$5" _commits_ref="$6"
+
+	# Resolve effective base ref once: prefer origin/<base>, fall back to bare <base>
+	local effective_base="origin/$base"
+	if ! git rev-parse "$effective_base" &>/dev/null; then
+		effective_base="$base"
+	fi
+
+	_diff_ref=$(git diff "$effective_base"..."$head" 2>/dev/null || true)
+	if [[ -z "$_diff_ref" ]]; then
+		gum log --level error "Failed to get diff between $base and $head"
+		return 1
+	fi
+
+	_stat_ref=$(git diff "$effective_base"..."$head" --stat 2>/dev/null || true)
+
+	_log_ref=$(git log --oneline "$effective_base".."$head" 2>/dev/null || true)
+
+	# shellcheck disable=SC2001
+	_commits_ref=$(printf '%s\n' "$_log_ref" | sed 's/^[a-f0-9]* /- /')
+}
+
+# Generate a UUIDv5 from a name using the NAMESPACE_URL (RFC 4122)
+#
+# Pure bash implementation — uses printf for the 16-byte NAMESPACE_URL raw
+# bytes and shasum -a 1 (both ship with macOS/Linux).
+#
+# Usage: _uuidv5 "https://github.com/owner/repo/issues/42"
+_uuidv5() {
+	local name="$1"
+	local hash
+	hash=$({
+		printf '\x6b\xa7\xb8\x11\x9d\xad\x11\xd1\x80\xb4\x00\xc0\x4f\xd4\x30\xc8'
+		printf '%s' "$name"
+	} | shasum -a 1 | cut -d' ' -f1)
+	local h="${hash:0:32}"
+	local byte6 byte8
+	byte6=$(printf '%02x' $((0x${h:12:2} & 0x0f | 0x50)))
+	byte8=$(printf '%02x' $((0x${h:16:2} & 0x3f | 0x80)))
+	printf '%s-%s-%s%s-%s%s-%s\n' \
+		"${h:0:8}" "${h:8:4}" "$byte6" "${h:14:2}" "$byte8" "${h:18:2}" "${h:20:12}"
+}
+
+# Resolve session state: validate inputs, compute IDs, and locate state file
+#
+# Shared helper for _try_resume_chat_session and _resolve_chat_session.
+# Validates the resource URL, checks passthrough for user session flags,
+# generates a deterministic session ID, derives the worktree name, resolves
+# the git root, computes the state file path, and handles --reset deletion.
+#
+# Returns 1 (skip) when URL is empty, user passed session flags, or git root
+# is unavailable.  On success, populates the three namerefs and returns 0.
+#
+# Usage: _resolve_session_state sid_ref name_ref path_ref "$url" "$reset" "${passthrough[@]}"
+_resolve_session_state() {
+	local -n _ss_sid="$1" _ss_name="$2" _ss_path="$3"
+	local resource_url="$4"
+	local reset="$5"
+	shift 5
+
+	if [[ -z "$resource_url" ]]; then
+		return 1
+	fi
+
+	local arg
+	for arg in "$@"; do
+		case "$arg" in
+		--resume | --resume=* | --session-id | --session-id=* | --continue | -c)
+			return 1
+			;;
+		esac
+	done
+
+	_ss_sid=$(_uuidv5 "$resource_url")
+
+	# Derive worktree name from last two URL path segments (e.g. "issues/42" → "issue-42")
+	_ss_name=$(printf '%s' "$resource_url" | awk -F/ '{sub(/s$/, "", $(NF-1)); print $(NF-1) "-" $NF}')
+
+	local git_root
+	_git_repo_path git_root || return 1
+
+	_ss_path="$git_root/.claude/sessions/${_ss_sid}.json"
+
+	if [[ -n "$reset" && -f "$_ss_path" ]]; then
+		rm -f "$_ss_path"
+	fi
+}
+
+# Try to resume an existing chat session
+#
+# Checks if a session state file exists for the given resource URL and
+# populates session arguments for resumption. Does NOT create new sessions.
+# When reset is non-empty, deletes the existing state file before checking.
+# Returns 0 if session can be resumed, 1 if a new session is needed.
+#
+# Usage: _try_resume_chat_session session_args_ref "https://github.com/..." "$reset" "${passthrough[@]}"
+_try_resume_chat_session() {
+	local -n _session_args_ref="$1"
+	local resource_url="$2"
+	local reset="$3"
+	shift 3
+
+	_session_args_ref=()
+
+	local session_id="" name="" state_file=""
+	_resolve_session_state session_id name state_file "$resource_url" "$reset" "$@" || return 1
+
+	if [[ -f "$state_file" ]]; then
+		_session_args_ref=(--resume "$session_id" --worktree "$name")
+		return 0
+	fi
+
+	return 1
+}
+
+# Resolve session arguments for chat commands
+#
+# Manages session state files for chat session persistence. On first run,
+# creates a state file with the session ID, worktree name, and remote ref,
+# then returns --session-id + --worktree. On subsequent runs, returns
+# --resume + --worktree. Silently skips when the URL is empty, the user
+# passed their own session flags, or the git root is unavailable.
+#
+# The remote_ref parameter specifies which branch to track in the worktree
+# (e.g. the PR head branch). When empty, defaults to the repository's
+# default branch via origin/HEAD.
+#
+# Usage: _resolve_chat_session session_args_ref "https://github.com/owner/repo/issues/42" "$reset" "$remote_ref" "${passthrough[@]}"
+_resolve_chat_session() {
+	local -n _session_args_ref="$1"
+	local resource_url="$2"
+	local reset="$3"
+	local remote_ref="$4"
+	shift 4
+
+	_session_args_ref=()
+
+	local session_id="" name="" state_file=""
+	_resolve_session_state session_id name state_file "$resource_url" "$reset" "$@" || return 0
+
+	mkdir -p "$(dirname "$state_file")"
+
+	if [[ -f "$state_file" ]]; then
+		_session_args_ref=(--resume "$session_id" --worktree "$name")
+	else
+		# Default to the repository's default branch when no remote ref is provided
+		if [[ -z "$remote_ref" ]]; then
+			remote_ref=$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||')
+			remote_ref="${remote_ref:-main}"
+		fi
+		jq -n --arg session_id "$session_id" --arg name "$name" --arg remote_ref "$remote_ref" \
+			'{session_id: $session_id, name: $name, remote_ref: $remote_ref}' >"$state_file"
+		_session_args_ref=(--session-id "$session_id" --worktree "$name")
 	fi
 }
 

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -234,7 +234,13 @@ _gh_issue_edit() {
 	output=$(
 		gum spin --title "Generating updated GitHub issue #$gh_issue_number..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GH_ISSUE_NUMBER="$gh_issue_number" GH_ISSUE_TITLE="$gh_issue_title" GH_ISSUE_BODY="$gh_issue_body" GH_ISSUE_LABELS="$gh_issue_labels" GH_ISSUE_COMMENTS="$gh_issue_comments" GH_ISSUE_DESCRIPTION="$gh_issue_description" GH_ISSUE_CONTEXT="$gh_issue_context" \
+				GH_ISSUE_NUMBER="$gh_issue_number" \
+					GH_ISSUE_TITLE="$gh_issue_title" \
+					GH_ISSUE_BODY="$gh_issue_body" \
+					GH_ISSUE_LABELS="$gh_issue_labels" \
+					GH_ISSUE_COMMENTS="$gh_issue_comments" \
+					GH_ISSUE_DESCRIPTION="$gh_issue_description" \
+					GH_ISSUE_CONTEXT="$gh_issue_context" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -248,14 +254,14 @@ _gh_issue_edit() {
 
 	local gh_issue_new_title
 	# Parse title from output
-	if ! gh_issue_new_title=$(_get_title "$output"); then
+	if ! gh_issue_new_title=$(_parse_title "$output"); then
 		gum log --level error "Failed to extract title from AI content"
 		return 1
 	fi
 
 	local gh_issue_new_body
 	# Parse body from output
-	gh_issue_new_body=$(_get_body "$output")
+	gh_issue_new_body=$(_parse_body "$output")
 
 	# Edit issue with AI-generated content
 	gh issue edit "$gh_issue_number" --title "$gh_issue_new_title" --body "$gh_issue_new_body" "${passthrough[@]}"
@@ -388,12 +394,22 @@ _gh_issue_plan() {
 	local agent_model
 	agent_model=$(gh config get ai.issue.model 2>/dev/null || true)
 
+	local gh_issue_focus=""
+	if [[ -n "$gh_issue_description" ]]; then
+		gh_issue_focus="<focus>${gh_issue_description}</focus>"
+	fi
+
 	local output
 	# Generate implementation plan using assistant
 	output=$(
 		gum spin --title "Generating GitHub issue #$gh_issue_number implementation plan..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GH_ISSUE_NUMBER="$gh_issue_number" GH_ISSUE_TITLE="$gh_issue_title" GH_ISSUE_BODY="$gh_issue_body" GH_ISSUE_LABELS="$gh_issue_labels" GH_ISSUE_COMMENTS="$gh_issue_comments" GH_ISSUE_DESCRIPTION="$gh_issue_description" \
+				GH_ISSUE_NUMBER="$gh_issue_number" \
+					GH_ISSUE_TITLE="$gh_issue_title" \
+					GH_ISSUE_BODY="$gh_issue_body" \
+					GH_ISSUE_LABELS="$gh_issue_labels" \
+					GH_ISSUE_COMMENTS="$gh_issue_comments" \
+					GH_ISSUE_FOCUS="$gh_issue_focus" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -410,14 +426,15 @@ _gh_issue_plan() {
 
 # Parse issue chat arguments
 #
-# Extracts the issue number (first numeric positional arg) and optional
-# -d/--description value. Unknown flags produce an error.
+# Extracts the issue number (first numeric positional arg), optional
+# -d/--description value, and --reset flag. Unknown flags produce an error.
 #
-# Example: _parse_issue_chat_args num desc 42 -d "focus on auth"
+# Example: _parse_issue_chat_args num desc reset 42 -d "focus on auth"
 _parse_issue_chat_args() {
 	local -n gh_issue_number_ref="$1"
 	local -n gh_issue_description_ref="$2"
-	shift 2
+	local -n gh_issue_reset_ref="$3"
+	shift 3
 
 	local raw_args=("$@")
 	local skip_next=false
@@ -442,6 +459,10 @@ _parse_issue_chat_args() {
 		--description=*)
 			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_issue_description_ref="${raw_args[$i]#--description=}"
+			;;
+		--reset)
+			# shellcheck disable=SC2034 # nameref: set by caller
+			gh_issue_reset_ref=1
 			;;
 		-*)
 			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to the agent)"
@@ -481,10 +502,12 @@ DESCRIPTION:
 
 FLAGS:
     -d, --description string   Extra context or focus for the agent (optional)
+        --reset                Reset session state and start a new session
 
 EXAMPLES:
     gh ai issue chat 42
     gh ai issue chat 42 -d "focus on the auth module"
+    gh ai issue chat 42 --reset
     gh ai issue chat 42 -- --model sonnet
 EOF
 }
@@ -513,12 +536,24 @@ _gh_issue_chat() {
 
 	local gh_issue_number=""
 	local gh_issue_description=""
-	_parse_issue_chat_args gh_issue_number gh_issue_description "${ai_args[@]}"
+	local gh_issue_reset=""
+	_parse_issue_chat_args gh_issue_number gh_issue_description gh_issue_reset "${ai_args[@]}"
 
 	if [[ -z "$gh_issue_number" ]]; then
 		gum log --level error "No issue number provided"
 		gum log --level info "Usage: gh ai issue chat <ISSUE_NUMBER> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]"
 		return 1
+	fi
+
+	# Try to resume existing session before expensive API calls
+	local gh_repo=""
+	_gh_repo_name gh_repo || return 1
+	local gh_issue_url="https://github.com/${gh_repo}/issues/${gh_issue_number}"
+
+	local session_args=()
+	if _try_resume_chat_session session_args "$gh_issue_url" "$gh_issue_reset" "${passthrough[@]}"; then
+		_cmd_chat "" "${session_args[@]}" "${passthrough[@]}"
+		return
 	fi
 
 	# Fetch issue metadata
@@ -534,14 +569,27 @@ _gh_issue_chat() {
 	local gh_issue_title gh_issue_body gh_issue_labels gh_issue_comments
 	eval "$gh_issue_eval"
 
+	local gh_issue_focus=""
+	if [[ -n "$gh_issue_description" ]]; then
+		gh_issue_focus="<focus>${gh_issue_description}</focus>"
+	fi
+
 	# Render context and pipe to agent
 	local preamble
 	preamble=$(
-		GH_ISSUE_NUMBER="$gh_issue_number" GH_ISSUE_TITLE="$gh_issue_title" GH_ISSUE_BODY="$gh_issue_body" GH_ISSUE_LABELS="$gh_issue_labels" GH_ISSUE_COMMENTS="$gh_issue_comments" GH_ISSUE_DESCRIPTION="$gh_issue_description" \
+		GH_ISSUE_NUMBER="$gh_issue_number" \
+			GH_ISSUE_TITLE="$gh_issue_title" \
+			GH_ISSUE_BODY="$gh_issue_body" \
+			GH_ISSUE_LABELS="$gh_issue_labels" \
+			GH_ISSUE_COMMENTS="$gh_issue_comments" \
+			GH_ISSUE_FOCUS="$gh_issue_focus" \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 	)
 
-	_cmd_chat "$preamble" "${passthrough[@]}"
+	session_args=()
+	_resolve_chat_session session_args "$gh_issue_url" "$gh_issue_reset" "" "${passthrough[@]}"
+
+	_cmd_chat "$preamble" "${session_args[@]}" "${passthrough[@]}"
 }
 
 # Issue create help function
@@ -618,7 +666,9 @@ _gh_issue_create() {
 	output=$(
 		gum spin --title "Generating GitHub issue..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GH_ISSUE_DESCRIPTION="$gh_issue_description" GH_ISSUE_LABELS="" GH_ISSUE_CONTEXT="$gh_issue_context" \
+				GH_ISSUE_DESCRIPTION="$gh_issue_description" \
+					GH_ISSUE_LABELS="" \
+					GH_ISSUE_CONTEXT="$gh_issue_context" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -632,14 +682,14 @@ _gh_issue_create() {
 
 	local gh_issue_title
 	# Parse title from output
-	if ! gh_issue_title=$(_get_title "$output"); then
+	if ! gh_issue_title=$(_parse_title "$output"); then
 		gum log --level error "Failed to extract title from AI content"
 		return 1
 	fi
 
 	local gh_issue_body
 	# Parse body from output
-	gh_issue_body=$(_get_body "$output")
+	gh_issue_body=$(_parse_body "$output")
 
 	# Create issue with AI-generated content
 	gh issue create --title "$gh_issue_title" --body "$gh_issue_body" "${passthrough[@]}"

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -135,42 +135,28 @@ _gh_pr_create() {
 			gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")
 	fi
 
-	# Get diff between base and head
-	local git_diff
-	# shellcheck disable=SC2140
-	git_diff=$(git diff "origin/$git_base_branch"..."$git_head_branch" 2>/dev/null || true)
-	if [[ -z "$git_diff" ]]; then
-		# Fallback: try without origin prefix
-		git_diff=$(git diff "$git_base_branch"..."$git_head_branch" 2>/dev/null || true)
-	fi
-	if [[ -z "$git_diff" ]]; then
-		gum log --level error "Failed to get diff between $git_base_branch and $git_head_branch"
-		return 1
-	fi
-
-	local git_diff_stat
-	# shellcheck disable=SC2140
-	git_diff_stat=$(git diff "origin/$git_base_branch"..."$git_head_branch" --stat 2>/dev/null ||
-		git diff "$git_base_branch"..."$git_head_branch" --stat 2>/dev/null || true)
-
-	local git_log
-	# shellcheck disable=SC2140
-	git_log=$(git log --oneline "origin/$git_base_branch".."$git_head_branch" 2>/dev/null ||
-		git log --oneline "$git_base_branch".."$git_head_branch" 2>/dev/null || true)
-
-	local git_log_oneline
-	# shellcheck disable=SC2001
-	git_log_oneline=$(printf '%s\n' "$git_log" | sed 's/^[a-f0-9]* /- /')
+	local gh_pr_diff="" gh_pr_diff_stat="" gh_pr_log="" gh_pr_commits=""
+	_git_branch_diff "$git_base_branch" "$git_head_branch" \
+		gh_pr_diff gh_pr_diff_stat gh_pr_log gh_pr_commits
 
 	local agent_model
 	agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
+
+	local gh_pr_description_context=""
+	if [[ -n "$gh_pr_description" ]]; then
+		gh_pr_description_context="<description>${gh_pr_description}</description>"
+	fi
 
 	local output
 	# Generate PR content using assistant run
 	output=$(
 		gum spin --title "Generating GitHub pull request..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" GIT_LOG="$git_log" GIT_COMMITS="$git_log_oneline" GH_PR_DESCRIPTION="$gh_pr_description" \
+				GH_PR_DIFF="$gh_pr_diff" \
+					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
+					GH_PR_LOG="$gh_pr_log" \
+					GH_PR_COMMITS="$gh_pr_commits" \
+					GH_PR_DESCRIPTION="$gh_pr_description_context" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -184,14 +170,14 @@ _gh_pr_create() {
 
 	local gh_pr_title
 	# Parse title from output
-	if ! gh_pr_title=$(_get_title "$output"); then
+	if ! gh_pr_title=$(_parse_title "$output"); then
 		gum log --level error "Failed to extract title from AI content"
 		return 1
 	fi
 
 	local gh_pr_body
 	# Parse body from output
-	gh_pr_body=$(_get_body "$output")
+	gh_pr_body=$(_parse_body "$output")
 
 	# Inject --base into passthrough only if the user explicitly specified it
 	if [[ -n "$user_specified_base" ]]; then
@@ -331,31 +317,27 @@ _gh_pr_edit() {
 	# Fetch PR metadata
 	local gh_pr_eval
 	gh_pr_eval=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number metadata..." -- \
-		gh pr view "$gh_pr_number" --json title,body \
+		gh pr view "$gh_pr_number" --json title,body,commits \
 		-q "$(<"$_gh_ai_source_dir/scripts/gh_pr_meta.jq")" || true)
 	if [[ -z "$gh_pr_eval" ]]; then
 		gum log --level error "Failed to fetch PR #$gh_pr_number"
 		return 1
 	fi
 
-	local gh_pr_title gh_pr_body
+	local gh_pr_title gh_pr_body gh_pr_head gh_pr_commits
 	eval "$gh_pr_eval"
 
 	# Get PR diff using gh cli (--patch for full patch format)
-	local git_diff
-	git_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
+	local gh_pr_diff
+	gh_pr_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
 		gh pr diff "$gh_pr_number" --patch || true)
-	if [[ -z "$git_diff" ]]; then
+	if [[ -z "$gh_pr_diff" ]]; then
 		gum log --level error "Failed to get diff for PR #$gh_pr_number"
 		return 1
 	fi
 
-	local git_diff_stat
-	git_diff_stat=$(echo "$git_diff" | git apply --stat 2>/dev/null || true)
-
-	local git_commit_list
-	git_commit_list=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number commits..." -- \
-		gh pr view "$gh_pr_number" --json commits -q '.commits[] | "- " + .messageHeadline' || true)
+	local gh_pr_diff_stat
+	gh_pr_diff_stat=$(echo "$gh_pr_diff" | git apply --stat 2>/dev/null || true)
 
 	local agent_model
 	agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
@@ -365,7 +347,13 @@ _gh_pr_edit() {
 	output=$(
 		gum spin --title "Generating updated GitHub pull request #$gh_pr_number..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GH_PR_NUMBER="$gh_pr_number" GH_PR_TITLE="$gh_pr_title" GH_PR_BODY="$gh_pr_body" GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" GIT_COMMITS="$git_commit_list" GH_PR_DESCRIPTION="$gh_pr_description" \
+				GH_PR_NUMBER="$gh_pr_number" \
+					GH_PR_TITLE="$gh_pr_title" \
+					GH_PR_BODY="$gh_pr_body" \
+					GH_PR_DIFF="$gh_pr_diff" \
+					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
+					GH_PR_COMMITS="$gh_pr_commits" \
+					GH_PR_DESCRIPTION="$gh_pr_description" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -379,14 +367,14 @@ _gh_pr_edit() {
 
 	local gh_pr_new_title
 	# Parse title from output
-	if ! gh_pr_new_title=$(_get_title "$output"); then
+	if ! gh_pr_new_title=$(_parse_title "$output"); then
 		gum log --level error "Failed to extract title from AI content"
 		return 1
 	fi
 
 	local gh_pr_new_body
 	# Parse body from output
-	gh_pr_new_body=$(_get_body "$output")
+	gh_pr_new_body=$(_parse_body "$output")
 
 	# Edit PR with AI-generated content
 	gh pr edit "$gh_pr_number" --title "$gh_pr_new_title" --body "$gh_pr_new_body" "${passthrough[@]}"
@@ -563,25 +551,28 @@ _gh_pr_review() {
 		return 1
 	fi
 
+	# Fetch PR metadata
+	local gh_pr_eval
+	gh_pr_eval=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number metadata..." -- \
+		gh pr view "$gh_pr_number" --json headRefName,commits \
+		-q "$(<"$_gh_ai_source_dir/scripts/gh_pr_meta.jq")" || true)
+
+	local gh_pr_title gh_pr_body gh_pr_head gh_pr_commits
+	if [[ -n "$gh_pr_eval" ]]; then
+		eval "$gh_pr_eval"
+	fi
+
 	# Get PR diff using gh cli (--patch for full patch format)
-	local git_diff
-	git_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
+	local gh_pr_diff
+	gh_pr_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
 		gh pr diff "$gh_pr_number" --patch || true)
-	if [[ -z "$git_diff" ]]; then
+	if [[ -z "$gh_pr_diff" ]]; then
 		gum log --level error "Failed to get diff for PR #$gh_pr_number"
 		return 1
 	fi
 
-	local git_diff_stat
-	git_diff_stat=$(echo "$git_diff" | git apply --stat 2>/dev/null || true)
-
-	local git_commit_list
-	git_commit_list=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number commits..." -- \
-		gh pr view "$gh_pr_number" --json commits -q '.commits[] | "- " + .messageHeadline' || true)
-
-	local git_branch
-	git_branch=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number branch..." -- \
-		gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' || true)
+	local gh_pr_diff_stat
+	gh_pr_diff_stat=$(echo "$gh_pr_diff" | git apply --stat 2>/dev/null || true)
 
 	local agent_model
 	agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
@@ -596,7 +587,12 @@ _gh_pr_review() {
 	gh_pr_body=$(
 		gum spin --title "Generating GitHub pull request #$gh_pr_number review..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" GIT_COMMITS="$git_commit_list" GIT_BRANCH="$git_branch" GH_PR_REVIEW_DESCRIPTION="$gh_pr_description_context" \
+				GH_PR_NUMBER="$gh_pr_number" \
+					GH_PR_DIFF="$gh_pr_diff" \
+					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
+					GH_PR_COMMITS="$gh_pr_commits" \
+					GH_PR_HEAD="$gh_pr_head" \
+					GH_PR_DESCRIPTION="$gh_pr_description_context" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -668,36 +664,28 @@ _gh_pr_explain() {
 		return 1
 	fi
 
+	# Fetch PR metadata
+	local gh_pr_eval
+	gh_pr_eval=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number metadata..." -- \
+		gh pr view "$gh_pr_number" --json title,body,headRefName,commits \
+		-q "$(<"$_gh_ai_source_dir/scripts/gh_pr_meta.jq")" || true)
+
+	local gh_pr_title gh_pr_body gh_pr_head gh_pr_commits
+	if [[ -n "$gh_pr_eval" ]]; then
+		eval "$gh_pr_eval"
+	fi
+
 	# Get PR diff using gh cli (--patch for full patch format)
-	local git_diff
-	git_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
+	local gh_pr_diff
+	gh_pr_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
 		gh pr diff "$gh_pr_number" --patch || true)
-	if [[ -z "$git_diff" ]]; then
+	if [[ -z "$gh_pr_diff" ]]; then
 		gum log --level error "Failed to get diff for PR #$gh_pr_number"
 		return 1
 	fi
 
-	local git_diff_stat
-	git_diff_stat=$(echo "$git_diff" | git apply --stat 2>/dev/null || true)
-
-	local git_commit_list
-	git_commit_list=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number commits..." -- \
-		gh pr view "$gh_pr_number" --json commits -q '.commits[] | "- " + .messageHeadline' || true)
-
-	local git_branch
-	git_branch=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number branch..." -- \
-		gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' || true)
-
-	# Fetch PR title and body
-	local gh_pr_eval
-	gh_pr_eval=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number metadata..." -- \
-		gh pr view "$gh_pr_number" --json title,body \
-		-q "$(<"$_gh_ai_source_dir/scripts/gh_pr_meta.jq")" || true)
-
-	local gh_pr_title gh_pr_body
-	if [[ -n "$gh_pr_eval" ]]; then
-		eval "$gh_pr_eval"
-	fi
+	local gh_pr_diff_stat
+	gh_pr_diff_stat=$(echo "$gh_pr_diff" | git apply --stat 2>/dev/null || true)
 
 	local agent_model
 	agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
@@ -707,8 +695,13 @@ _gh_pr_explain() {
 	output=$(
 		gum spin --title "Generating GitHub pull request #$gh_pr_number explanation..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GH_PR_TITLE="$gh_pr_title" GH_PR_BODY="$gh_pr_body" GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" \
-					GIT_COMMITS="$git_commit_list" GIT_BRANCH="$git_branch" \
+				GH_PR_NUMBER="$gh_pr_number" \
+					GH_PR_TITLE="$gh_pr_title" \
+					GH_PR_BODY="$gh_pr_body" \
+					GH_PR_DIFF="$gh_pr_diff" \
+					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
+					GH_PR_COMMITS="$gh_pr_commits" \
+					GH_PR_HEAD="$gh_pr_head" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -736,14 +729,15 @@ _gh_pr_explain() {
 
 # Parse PR chat arguments
 #
-# Extracts the PR number (first numeric arg, with auto-detect fallback)
-# and -d/--description value. Unknown flags produce an error.
+# Extracts the PR number (first numeric arg, with auto-detect fallback),
+# -d/--description value, and --reset flag. Unknown flags produce an error.
 #
-# Example: _parse_pr_chat_args num desc 42 -d "focus on security"
+# Example: _parse_pr_chat_args num desc reset 42 -d "focus on security"
 _parse_pr_chat_args() {
 	local -n gh_pr_number_ref="$1"
 	local -n gh_pr_description_ref="$2"
-	shift 2
+	local -n gh_pr_reset_ref="$3"
+	shift 3
 
 	local raw_args=("$@")
 	local skip_next=false
@@ -768,6 +762,10 @@ _parse_pr_chat_args() {
 		--description=*)
 			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_pr_description_ref="${raw_args[$i]#--description=}"
+			;;
+		--reset)
+			# shellcheck disable=SC2034 # nameref: set by caller
+			gh_pr_reset_ref=1
 			;;
 		-*)
 			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to the agent)"
@@ -813,10 +811,12 @@ DESCRIPTION:
 
 FLAGS:
     -d, --description string   Extra context or focus for the agent (optional)
+        --reset                Reset session state and start a new session
 
 EXAMPLES:
     gh ai pr chat 42
     gh ai pr chat -d "focus on the security changes"
+    gh ai pr chat 42 --reset
     gh ai pr chat                    # auto-detect PR from current branch
     gh ai pr chat 42 -- --model sonnet
 EOF
@@ -846,7 +846,8 @@ _gh_pr_chat() {
 
 	local gh_pr_number=""
 	local gh_pr_description=""
-	_parse_pr_chat_args gh_pr_number gh_pr_description "${ai_args[@]}"
+	local gh_pr_reset=""
+	_parse_pr_chat_args gh_pr_number gh_pr_description gh_pr_reset "${ai_args[@]}"
 
 	if [[ -z "$gh_pr_number" ]]; then
 		gum log --level error "No PR number provided and could not detect PR for current branch"
@@ -854,30 +855,33 @@ _gh_pr_chat() {
 		return 1
 	fi
 
+	# Try to resume existing session before expensive API calls
+	local gh_repo=""
+	_gh_repo_name gh_repo || return 1
+	local gh_pr_url="https://github.com/${gh_repo}/pull/${gh_pr_number}"
+
+	local session_args=()
+	if _try_resume_chat_session session_args "$gh_pr_url" "$gh_pr_reset" "${passthrough[@]}"; then
+		_cmd_chat "" "${session_args[@]}" "${passthrough[@]}"
+		return
+	fi
+
 	# Get PR diff using gh cli (--patch for full patch format)
-	local git_diff
-	git_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
+	local gh_pr_diff
+	gh_pr_diff=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number diff..." -- \
 		gh pr diff "$gh_pr_number" --patch || true)
-	if [[ -z "$git_diff" ]]; then
+	if [[ -z "$gh_pr_diff" ]]; then
 		gum log --level error "Failed to get diff for PR #$gh_pr_number"
 		return 1
 	fi
 
-	local git_diff_stat
-	git_diff_stat=$(echo "$git_diff" | git apply --stat 2>/dev/null || true)
-
-	local git_commit_list
-	git_commit_list=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number commits..." -- \
-		gh pr view "$gh_pr_number" --json commits -q '.commits[] | "- " + .messageHeadline' || true)
-
-	local git_branch
-	git_branch=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number branch..." -- \
-		gh pr view "$gh_pr_number" --json headRefName -q '.headRefName' || true)
+	local gh_pr_diff_stat
+	gh_pr_diff_stat=$(echo "$gh_pr_diff" | git apply --stat 2>/dev/null || true)
 
 	# Fetch PR title and body
 	local gh_pr_eval
 	gh_pr_eval=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number metadata..." -- \
-		gh pr view "$gh_pr_number" --json title,body \
+		gh pr view "$gh_pr_number" --json title,body,headRefName,commits \
 		-q "$(<"$_gh_ai_source_dir/scripts/gh_pr_meta.jq")" || true)
 
 	if [[ -z "$gh_pr_eval" ]]; then
@@ -885,17 +889,32 @@ _gh_pr_chat() {
 		return 1
 	fi
 
-	local gh_pr_title gh_pr_body
+	local gh_pr_title gh_pr_body gh_pr_head gh_pr_commits
 	eval "$gh_pr_eval"
 
 	# Render context and pipe to agent
+	local gh_pr_focus=""
+	if [[ -n "$gh_pr_description" ]]; then
+		gh_pr_focus="<focus>${gh_pr_description}</focus>"
+	fi
+
 	local preamble
 	preamble=$(
-		GH_PR_NUMBER="$gh_pr_number" GH_PR_TITLE="$gh_pr_title" GH_PR_BODY="$gh_pr_body" GIT_DIFF="$git_diff" GIT_DIFF_STAT="$git_diff_stat" GIT_COMMITS="$git_commit_list" GIT_BRANCH="$git_branch" GH_PR_DESCRIPTION="$gh_pr_description" \
+		GH_PR_NUMBER="$gh_pr_number" \
+			GH_PR_TITLE="$gh_pr_title" \
+			GH_PR_BODY="$gh_pr_body" \
+			GH_PR_DIFF="$gh_pr_diff" \
+			GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
+			GH_PR_COMMITS="$gh_pr_commits" \
+			GH_PR_HEAD="$gh_pr_head" \
+			GH_PR_FOCUS="$gh_pr_focus" \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 	)
 
-	_cmd_chat "$preamble" "${passthrough[@]}"
+	session_args=()
+	_resolve_chat_session session_args "$gh_pr_url" "$gh_pr_reset" "$gh_pr_head" "${passthrough[@]}"
+
+	_cmd_chat "$preamble" "${session_args[@]}" "${passthrough[@]}"
 }
 
 # PR help function

--- a/scripts/gh_pr_meta.jq
+++ b/scripts/gh_pr_meta.jq
@@ -1,2 +1,4 @@
 "gh_pr_title=" + (.title // "" | @sh),
-"gh_pr_body=" + (.body // "" | @sh)
+"gh_pr_body=" + (.body // "" | @sh),
+"gh_pr_head=" + (.headRefName // "" | @sh),
+"gh_pr_commits=" + ([.commits[]? | "- " + .messageHeadline] | join("\n") | @sh)

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -155,7 +155,13 @@ _gh_run_explain() {
 	output=$(
 		gum spin --title "Analyzing GitHub workflow run #$gh_run_id..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GH_RUN_TITLE="$gh_run_title" GH_RUN_CONCLUSION="$gh_run_conclusion" GH_RUN_URL="$gh_run_url" GH_RUN_EVENT="$gh_run_event" GH_RUN_BRANCH="$gh_run_branch" GH_RUN_JOBS="$gh_run_jobs" GH_RUN_LOG="$gh_run_log" \
+				GH_RUN_TITLE="$gh_run_title" \
+					GH_RUN_CONCLUSION="$gh_run_conclusion" \
+					GH_RUN_URL="$gh_run_url" \
+					GH_RUN_EVENT="$gh_run_event" \
+					GH_RUN_BRANCH="$gh_run_branch" \
+					GH_RUN_JOBS="$gh_run_jobs" \
+					GH_RUN_LOG="$gh_run_log" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
@@ -172,14 +178,15 @@ _gh_run_explain() {
 
 # Parse run chat arguments
 #
-# Extracts the run ID (first numeric arg) and optional -d/--description value.
-# Unknown flags produce an error.
+# Extracts the run ID (first numeric arg), optional -d/--description value,
+# and --reset flag. Unknown flags produce an error.
 #
-# Example: _parse_run_chat_args id desc 123456 -d "focus on test failures"
+# Example: _parse_run_chat_args id desc reset 123456 -d "focus on test failures"
 _parse_run_chat_args() {
 	local -n gh_run_id_ref="$1"
 	local -n gh_run_description_ref="$2"
-	shift 2
+	local -n gh_run_reset_ref="$3"
+	shift 3
 
 	local raw_args=("$@")
 	local skip_next=false
@@ -204,6 +211,10 @@ _parse_run_chat_args() {
 		--description=*)
 			# shellcheck disable=SC2034 # nameref: set by caller
 			gh_run_description_ref="${raw_args[$i]#--description=}"
+			;;
+		--reset)
+			# shellcheck disable=SC2034 # nameref: set by caller
+			gh_run_reset_ref=1
 			;;
 		-*)
 			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to the agent)"
@@ -243,10 +254,12 @@ DESCRIPTION:
 
 FLAGS:
     -d, --description string   Extra context or focus for the agent (optional)
+        --reset                Reset session state and start a new session
 
 EXAMPLES:
     gh ai run chat 123456
     gh ai run chat 123456 -d "focus on test failures"
+    gh ai run chat 123456 --reset
     gh ai run chat 123456 -- --model sonnet
 EOF
 }
@@ -275,12 +288,24 @@ _gh_run_chat() {
 
 	local gh_run_id=""
 	local gh_run_description=""
-	_parse_run_chat_args gh_run_id gh_run_description "${ai_args[@]}"
+	local gh_run_reset=""
+	_parse_run_chat_args gh_run_id gh_run_description gh_run_reset "${ai_args[@]}"
 
 	if [[ -z "$gh_run_id" ]]; then
 		gum log --level error "No run ID provided"
 		gum log --level info "Usage: gh ai run chat <RUN_ID> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]"
 		return 1
+	fi
+
+	# Try to resume existing session before expensive API calls
+	local gh_repo=""
+	_gh_repo_name gh_repo || return 1
+	local gh_run_url="https://github.com/${gh_repo}/actions/runs/${gh_run_id}"
+
+	local session_args=()
+	if _try_resume_chat_session session_args "$gh_run_url" "$gh_run_reset" "${passthrough[@]}"; then
+		_cmd_chat "" "${session_args[@]}" "${passthrough[@]}"
+		return
 	fi
 
 	# Fetch run metadata
@@ -293,7 +318,7 @@ _gh_run_chat() {
 		return 1
 	fi
 
-	local gh_run_title gh_run_conclusion gh_run_url gh_run_event gh_run_branch gh_run_jobs
+	local gh_run_title gh_run_conclusion gh_run_event gh_run_branch gh_run_jobs
 	eval "$gh_run_eval"
 
 	# Fetch logs: use --log-failed for failed runs, --log otherwise
@@ -314,14 +339,30 @@ _gh_run_chat() {
 		gh_run_log="[... log truncated, showing last ${_max_log_bytes} bytes ...]"$'\n'"$_tail"
 	fi
 
+	local gh_run_focus=""
+	if [[ -n "$gh_run_description" ]]; then
+		gh_run_focus="<focus>${gh_run_description}</focus>"
+	fi
+
 	# Render context and pipe to agent
 	local preamble
 	preamble=$(
-		GH_RUN_ID="$gh_run_id" GH_RUN_TITLE="$gh_run_title" GH_RUN_CONCLUSION="$gh_run_conclusion" GH_RUN_URL="$gh_run_url" GH_RUN_EVENT="$gh_run_event" GH_RUN_BRANCH="$gh_run_branch" GH_RUN_JOBS="$gh_run_jobs" GH_RUN_LOG="$gh_run_log" GH_RUN_DESCRIPTION="$gh_run_description" \
+		GH_RUN_ID="$gh_run_id" \
+			GH_RUN_TITLE="$gh_run_title" \
+			GH_RUN_CONCLUSION="$gh_run_conclusion" \
+			GH_RUN_FOCUS="$gh_run_focus" \
+			GH_RUN_URL="$gh_run_url" \
+			GH_RUN_EVENT="$gh_run_event" \
+			GH_RUN_BRANCH="$gh_run_branch" \
+			GH_RUN_JOBS="$gh_run_jobs" \
+			GH_RUN_LOG="$gh_run_log" \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 	)
 
-	_cmd_chat "$preamble" "${passthrough[@]}"
+	session_args=()
+	_resolve_chat_session session_args "$gh_run_url" "$gh_run_reset" "" "${passthrough[@]}"
+
+	_cmd_chat "$preamble" "${session_args[@]}" "${passthrough[@]}"
 }
 
 # Run subcommand handler

--- a/scripts/gh_worktree.jq
+++ b/scripts/gh_worktree.jq
@@ -1,0 +1,4 @@
+(if .name            then "gh_worktree_name="        + (.name        | @sh) else empty end),
+(if .cwd             then "gh_worktree_cwd="         + (.cwd         | @sh) else empty end),
+(if .session_id      then "gh_worktree_session_id="  + (.session_id  | @sh) else empty end),
+(if .remote_ref      then "gh_worktree_remote_ref="  + (.remote_ref  | @sh) else empty end)

--- a/scripts/gh_worktree.sh
+++ b/scripts/gh_worktree.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Worktree hooks for Claude Code
+#
+# Subcommands:
+#   create — reads JSON {name, cwd} from stdin, creates a git worktree
+#            tracking the matching remote branch, prints worktree path
+#   remove — reads JSON {worktree_path} from stdin, removes the worktree
+
+set -euo pipefail
+
+_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Create a git worktree for a Claude Code session
+#
+# Reads JSON from stdin with "name", "cwd", and "session_id" fields.
+# Looks up the session state file to resolve the remote ref to track.
+# The local branch is named worktree-<name>.
+#
+# Stdin:  {"name": "issue-42", "cwd": "/path/to/repo", "session_id": "uuid"}
+# Stdout: worktree path (e.g. /path/to/repo/.claude/worktrees/issue-42)
+# Stderr: git worktree add output
+_gh_worktree_create() {
+	local input
+	input=$(cat)
+
+	local gh_worktree_jq
+	gh_worktree_jq=$(<"$_script_dir/gh_worktree.jq")
+
+	# First pass: extract name, cwd, session_id from Claude's hook JSON
+	local gh_worktree_name gh_worktree_cwd gh_worktree_session_id gh_worktree_remote_ref="main"
+	eval "$(printf '%s' "$input" | jq -r "$gh_worktree_jq")"
+
+	# Second pass: overlay remote_ref from the session state file (same jq filter)
+	local session_state_file="${gh_worktree_cwd}/.claude/sessions/${gh_worktree_session_id}.json"
+	if [[ -f "$session_state_file" ]]; then
+		eval "$(jq -r "$gh_worktree_jq" "$session_state_file")"
+	fi
+
+	local gh_worktree_path
+	gh_worktree_path="${gh_worktree_cwd}/.claude/worktrees/${gh_worktree_name}"
+
+	local git_ref="origin/${gh_worktree_remote_ref}"
+	git -C "$gh_worktree_cwd" worktree add -B "worktree-${gh_worktree_name}" "$gh_worktree_path" "$git_ref" >&2
+
+	printf '%s\n' "$gh_worktree_path"
+}
+
+# Remove a git worktree created by _gh_worktree_create
+#
+# Reads JSON from stdin with "worktree_path" field and force-removes
+# the worktree. Silently succeeds if the path does not exist.
+#
+# Stdin: {"worktree_path": "/path/to/repo/.claude/worktrees/issue-42"}
+_gh_worktree_remove() {
+	local worktree_path
+	worktree_path=$(jq -r .worktree_path)
+	git worktree remove -f "$worktree_path" 2>/dev/null || true
+}
+
+case "${1:-}" in
+create)
+	_gh_worktree_create
+	;;
+remove)
+	_gh_worktree_remove
+	;;
+*)
+	echo "Usage: gh_worktree.sh <create|remove>" >&2
+	exit 1
+	;;
+esac

--- a/templates/gh_issue_chat.tmpl
+++ b/templates/gh_issue_chat.tmpl
@@ -11,8 +11,18 @@ Labels: ${GH_ISSUE_LABELS}
 ${GH_ISSUE_COMMENTS}
 </comments>
 
-<focus>
-${GH_ISSUE_DESCRIPTION}
-</focus>
+${GH_ISSUE_FOCUS}
 
-IMPORTANT: Your first message contains the full context for GitHub issue #${GH_ISSUE_NUMBER}. Summarize the issue in your reply — do not use tools, read files, or explore the codebase. Then ask if the user wants to discuss it, plan an implementation, or start working. Only begin implementing once the user explicitly confirms.
+<instructions>
+Do not jump into implementation or change files unless clearly
+instructed to make changes. When the user's intent is ambiguous,
+default to providing information, doing research, and providing
+recommendations rather than taking action. Only proceed with edits,
+modifications, or implementations when the user explicitly requests
+them.
+
+Your first message contains the full context for GitHub issue
+#${GH_ISSUE_NUMBER}. Summarize the issue in your reply — do not use
+tools, read files, or explore the codebase. Then ask if the user
+wants to discuss it, plan an implementation, or start working.
+</instructions>

--- a/templates/gh_issue_plan.tmpl
+++ b/templates/gh_issue_plan.tmpl
@@ -11,9 +11,7 @@ Labels: ${GH_ISSUE_LABELS}
 ${GH_ISSUE_COMMENTS}
 </comments>
 
-<focus>
-${GH_ISSUE_DESCRIPTION}
-</focus>
+${GH_ISSUE_FOCUS}
 
 <format>
 - First line: PR title — `# {title}`, clear and specific, under 72 chars

--- a/templates/gh_pr_chat.tmpl
+++ b/templates/gh_pr_chat.tmpl
@@ -3,7 +3,7 @@ You are helping with a GitHub pull request. Here is the context:
 <pr>
 Number: ${GH_PR_NUMBER}
 Title: ${GH_PR_TITLE}
-Branch: ${GIT_BRANCH}
+Branch: ${GH_PR_HEAD}
 </pr>
 
 <description>
@@ -11,19 +11,30 @@ ${GH_PR_BODY}
 </description>
 
 <diffstat>
-${GIT_DIFF_STAT}
+${GH_PR_DIFF_STAT}
 </diffstat>
 
 <diff>
-${GIT_DIFF}
+${GH_PR_DIFF}
 </diff>
 
 <commits>
-${GIT_COMMITS}
+${GH_PR_COMMITS}
 </commits>
 
-<focus>
-${GH_PR_DESCRIPTION}
-</focus>
+${GH_PR_FOCUS}
 
-IMPORTANT: Your first message contains the full context for GitHub pull request #${GH_PR_NUMBER}. Summarize the changes in your reply — do not use tools, read files, or re-analyze the diff. Then ask how the user would like to proceed — review specific areas, discuss trade-offs, or ask questions. Do not commit or push changes unless the user explicitly asks.
+<instructions>
+Do not jump into implementation or change files unless clearly
+instructed to make changes. When the user's intent is ambiguous,
+default to providing information, doing research, and providing
+recommendations rather than taking action. Only proceed with edits,
+modifications, or implementations when the user explicitly requests
+them.
+
+Your first message contains the full context for GitHub pull request
+#${GH_PR_NUMBER}. Summarize the changes in your reply — do not use
+tools, read files, or re-analyze the diff. Then ask how the user
+would like to proceed — review specific areas, discuss trade-offs,
+or ask questions.
+</instructions>

--- a/templates/gh_pr_create.tmpl
+++ b/templates/gh_pr_create.tmpl
@@ -2,26 +2,24 @@ Write a GitHub pull request title and body for the changes below.
 If a description is provided, use it as guidance for emphasis and framing.
 
 <diffstat>
-${GIT_DIFF_STAT}
+${GH_PR_DIFF_STAT}
 </diffstat>
 
 <diff>
-${GIT_DIFF}
+${GH_PR_DIFF}
 </diff>
 
 <log>
-${GIT_LOG}
+${GH_PR_LOG}
 </log>
 
 <context>
 <recent_commits>
-${GIT_COMMITS}
+${GH_PR_COMMITS}
 </recent_commits>
 </context>
 
-<description>
 ${GH_PR_DESCRIPTION}
-</description>
 
 <format>
 - First line: PR title — imperative mood, under 72 chars, no trailing period

--- a/templates/gh_pr_edit.tmpl
+++ b/templates/gh_pr_edit.tmpl
@@ -7,15 +7,15 @@ Body: ${GH_PR_BODY}
 </pull_request>
 
 <diffstat>
-${GIT_DIFF_STAT}
+${GH_PR_DIFF_STAT}
 </diffstat>
 
 <diff>
-${GIT_DIFF}
+${GH_PR_DIFF}
 </diff>
 
 <commits>
-${GIT_COMMITS}
+${GH_PR_COMMITS}
 </commits>
 
 <requested_changes>

--- a/templates/gh_pr_explain.tmpl
+++ b/templates/gh_pr_explain.tmpl
@@ -1,8 +1,9 @@
 Explain what this pull request does in clear, accessible language.
 
 <pr>
+Number: ${GH_PR_NUMBER}
 Title: ${GH_PR_TITLE}
-Branch: ${GIT_BRANCH}
+Branch: ${GH_PR_HEAD}
 </pr>
 
 <current_description>
@@ -10,16 +11,16 @@ ${GH_PR_BODY}
 </current_description>
 
 <diffstat>
-${GIT_DIFF_STAT}
+${GH_PR_DIFF_STAT}
 </diffstat>
 
 <diff>
-${GIT_DIFF}
+${GH_PR_DIFF}
 </diff>
 
 <context>
 <recent_commits>
-${GIT_COMMITS}
+${GH_PR_COMMITS}
 </recent_commits>
 </context>
 

--- a/templates/gh_pr_review.tmpl
+++ b/templates/gh_pr_review.tmpl
@@ -1,21 +1,25 @@
 Review the pull request diff below. Assess the overall approach and design first, then examine individual changes.
 
+<pr>
+Number: ${GH_PR_NUMBER}
+Branch: ${GH_PR_HEAD}
+</pr>
+
 <diffstat>
-${GIT_DIFF_STAT}
+${GH_PR_DIFF_STAT}
 </diffstat>
 
 <diff>
-${GIT_DIFF}
+${GH_PR_DIFF}
 </diff>
 
 <context>
-Branch: ${GIT_BRANCH}
 <recent_commits>
-${GIT_COMMITS}
+${GH_PR_COMMITS}
 </recent_commits>
 </context>
 
-${GH_PR_REVIEW_DESCRIPTION}
+${GH_PR_DESCRIPTION}
 
 <priorities>
 Flag: bugs, security/data-loss issues, guideline violations, performance bottlenecks, missing error handling

--- a/templates/gh_run_chat.tmpl
+++ b/templates/gh_run_chat.tmpl
@@ -17,8 +17,19 @@ ${GH_RUN_JOBS}
 ${GH_RUN_LOG}
 </log>
 
-<focus>
-${GH_RUN_DESCRIPTION}
-</focus>
+${GH_RUN_FOCUS}
 
-IMPORTANT: Your first message contains the full context for GitHub Actions run #${GH_RUN_ID}. Analyze the run in your reply — do not use tools, re-fetch logs, or generate a new analysis. Then ask how the user would like to proceed — investigate specific failures, discuss fixes, or start implementing. Only begin making changes once the user explicitly confirms.
+<instructions>
+Do not jump into implementation or change files unless clearly
+instructed to make changes. When the user's intent is ambiguous,
+default to providing information, doing research, and providing
+recommendations rather than taking action. Only proceed with edits,
+modifications, or implementations when the user explicitly requests
+them.
+
+Your first message contains the full context for GitHub Actions run
+#${GH_RUN_ID}. Analyze the run in your reply — do not use tools,
+re-fetch logs, or generate a new analysis. Then ask how the user
+would like to proceed — investigate specific failures, discuss
+fixes, or start implementing.
+</instructions>

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -20,8 +20,8 @@ setup() {
 		export _gh_ai_source_dir="$REPO_ROOT"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _split_on_separator _cmd_render _get_title _get_body \
-			_get_repo_name _get_git_repo_path
+		declare -f _split_on_separator _cmd_render _parse_title _parse_body \
+			_gh_repo_name _git_repo_path _git_branch_diff _uuidv5
 	)"
 }
 
@@ -109,49 +109,112 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
-# _get_repo_name
+# _gh_repo_name
 # ---------------------------------------------------------------------------
 
-@test "_get_repo_name: sets nameref when gh repo view succeeds" {
+@test "_gh_repo_name: sets nameref when gh repo view succeeds" {
 	gh() { echo "owner/repo"; }
 	export -f gh
 
 	local repo=""
-	_get_repo_name repo
+	_gh_repo_name repo
 
 	[[ "$repo" == "owner/repo" ]]
 }
 
-@test "_get_repo_name: returns error when gh repo view returns empty" {
+@test "_gh_repo_name: returns error when gh repo view returns empty" {
 	gh() { :; }
 	export -f gh
 
 	local repo=""
-	run _get_repo_name repo
+	run _gh_repo_name repo
 
 	[[ "$status" -eq 1 ]]
 }
 
 # ---------------------------------------------------------------------------
-# _get_git_repo_path
+# _git_repo_path
 # ---------------------------------------------------------------------------
 
-@test "_get_git_repo_path: sets nameref when git rev-parse succeeds" {
+@test "_git_repo_path: sets nameref when git rev-parse succeeds" {
 	git() { echo "/home/user/myrepo"; }
 	export -f git
 
 	local dir=""
-	_get_git_repo_path dir
+	_git_repo_path dir
 
 	[[ "$dir" == "/home/user/myrepo" ]]
 }
 
-@test "_get_git_repo_path: returns error when git rev-parse returns empty" {
+@test "_git_repo_path: returns error when git rev-parse returns empty" {
 	git() { :; }
 	export -f git
 
 	local dir=""
-	run _get_git_repo_path dir
+	run _git_repo_path dir
+
+	[[ "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _git_branch_diff
+# ---------------------------------------------------------------------------
+
+@test "_git_branch_diff: populates all four namerefs" {
+	git() {
+		case "$1 $2" in
+		"diff origin/main...feature")
+			if [[ "${*}" == *"--stat"* ]]; then
+				echo " file.sh | 2 +-"
+			else
+				echo "diff --git a/file.sh b/file.sh"
+			fi
+			;;
+		"log --oneline") echo "abc1234 first commit" ;;
+		esac
+	}
+	export -f git
+
+	local diff="" stat="" log="" commits=""
+	_git_branch_diff main feature diff stat log commits
+
+	[[ "$diff" == "diff --git a/file.sh b/file.sh" ]]
+	[[ "$stat" == " file.sh | 2 +-" ]]
+	[[ "$log" == "abc1234 first commit" ]]
+	[[ "$commits" == "- first commit" ]]
+}
+
+@test "_git_branch_diff: falls back to bare branch when origin fails" {
+	git() {
+		case "$*" in
+		*origin/main*)
+			return 1
+			;;
+		"diff main...feature")
+			echo "diff --git a/file.sh b/file.sh"
+			;;
+		"diff main...feature --stat")
+			echo " file.sh | 2 +-"
+			;;
+		"log --oneline main..feature")
+			echo "abc1234 first commit"
+			;;
+		esac
+	}
+	export -f git
+
+	local diff="" stat="" log="" commits=""
+	_git_branch_diff main feature diff stat log commits
+
+	[[ "$diff" == "diff --git a/file.sh b/file.sh" ]]
+}
+
+@test "_git_branch_diff: returns error when diff is empty" {
+	git() { return 1; }
+	export -f git
+
+	local diff="" stat="" log="" commits=""
+	run _git_branch_diff main feature diff stat log commits
 
 	[[ "$status" -eq 1 ]]
 }
@@ -185,10 +248,10 @@ setup() {
 @test "_cmd_render: does not re-expand vars inside substituted values" {
 	local tmpdir="$BATS_TMPDIR/render-safe-test-$$"
 	mkdir -p "$tmpdir"
-	printf 'Diff: ${GIT_DIFF}\n' >"$tmpdir/test.tmpl"
+	printf 'Diff: ${GH_PR_DIFF}\n' >"$tmpdir/test.tmpl"
 
 	local output
-	output=$(GIT_DIFF='contains ${SECRET} token' _cmd_render "$tmpdir/test.tmpl")
+	output=$(GH_PR_DIFF='contains ${SECRET} token' _cmd_render "$tmpdir/test.tmpl")
 
 	[[ "$output" == *'contains ${SECRET} token'* ]]
 }
@@ -213,47 +276,47 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
-# _get_title
+# _parse_title
 # ---------------------------------------------------------------------------
 
-@test "_get_title: extracts title from markdown heading" {
+@test "_parse_title: extracts title from markdown heading" {
 	local output
-	output=$(_get_title "# Fix bug in parser
+	output=$(_parse_title "# Fix bug in parser
 
 Description of the fix.")
 
 	[[ "$output" == "Fix bug in parser" ]]
 }
 
-@test "_get_title: extracts title without heading prefix" {
+@test "_parse_title: extracts title without heading prefix" {
 	local output
-	output=$(_get_title "Add new feature
+	output=$(_parse_title "Add new feature
 
 Body text here.")
 
 	[[ "$output" == "Add new feature" ]]
 }
 
-@test "_get_title: returns error for empty content" {
-	run _get_title ""
+@test "_parse_title: returns error for empty content" {
+	run _parse_title ""
 
 	[[ "$status" -eq 1 ]]
 }
 
-@test "_get_title: strips only the first heading hash" {
+@test "_parse_title: strips only the first heading hash" {
 	local output
-	output=$(_get_title "## Sub heading title")
+	output=$(_parse_title "## Sub heading title")
 
 	[[ "$output" == "# Sub heading title" ]]
 }
 
 # ---------------------------------------------------------------------------
-# _get_body
+# _parse_body
 # ---------------------------------------------------------------------------
 
-@test "_get_body: extracts body after title line with footer" {
+@test "_parse_body: extracts body after title line with footer" {
 	local output
-	output=$(_get_body "# Title
+	output=$(_parse_body "# Title
 
 Body paragraph one.
 
@@ -264,9 +327,9 @@ Body paragraph two.")
 	[[ "$output" == *"markdownlint-disable-file"* ]]
 }
 
-@test "_get_body: strips leading blank lines" {
+@test "_parse_body: strips leading blank lines" {
 	local output
-	output=$(_get_body "# Title
+	output=$(_parse_body "# Title
 
 
 Actual body.")
@@ -276,9 +339,50 @@ Actual body.")
 	[[ "$output" == *"Actual body."* ]]
 }
 
-@test "_get_body: returns only footer for title-only content" {
+@test "_parse_body: returns only footer for title-only content" {
 	local output
-	output=$(_get_body "# Title only")
+	output=$(_parse_body "# Title only")
 
 	[[ "$output" == *"markdownlint-disable-file"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# _uuidv5
+# ---------------------------------------------------------------------------
+
+@test "_uuidv5: correct UUID for known issue URL" {
+	local output
+	output=$(_uuidv5 "https://github.com/owner/repo/issues/42")
+
+	[[ "$output" == "3c177fbc-2912-59eb-b754-8ff8b6e3021b" ]]
+}
+
+@test "_uuidv5: correct UUID for known PR URL" {
+	local output
+	output=$(_uuidv5 "https://github.com/gh-extensions/gh-ai/pull/7")
+
+	[[ "$output" == "06aecb08-6f37-5c60-807f-2d88b3f2cd2c" ]]
+}
+
+@test "_uuidv5: correct UUID for known run URL" {
+	local output
+	output=$(_uuidv5 "https://github.com/gh-extensions/gh-ai/actions/runs/123456")
+
+	[[ "$output" == "728ca934-ac63-5822-9504-56becd76d3e0" ]]
+}
+
+@test "_uuidv5: different inputs produce different UUIDs" {
+	local uuid1 uuid2
+	uuid1=$(_uuidv5 "https://github.com/owner/repo/issues/1")
+	uuid2=$(_uuidv5 "https://github.com/owner/repo/issues/2")
+
+	[[ "$uuid1" != "$uuid2" ]]
+}
+
+@test "_uuidv5: same input always produces same UUID" {
+	local uuid1 uuid2
+	uuid1=$(_uuidv5 "https://github.com/owner/repo/issues/42")
+	uuid2=$(_uuidv5 "https://github.com/owner/repo/issues/42")
+
+	[[ "$uuid1" == "$uuid2" ]]
 }

--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -9,10 +9,17 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
+	export HOME="$BATS_TEST_TMPDIR"
 
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
-	export -f gum gh
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$BATS_TEST_TMPDIR" ;;
+		"rev-parse --abbrev-ref") echo "" ;;
+		esac
+	}
+	export -f gum gh git
 
 	# shellcheck disable=SC2155
 	eval "$(
@@ -21,7 +28,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_issue.sh"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _parse_issue_chat_args _show_issue_chat_help _gh_issue_chat _cmd_chat _cmd_render _split_on_separator _get_agent
+		declare -f _parse_issue_chat_args _show_issue_chat_help _gh_issue_chat _cmd_chat _cmd_render _split_on_separator _get_agent _uuidv5 _git_repo_path _resolve_session_state _try_resume_chat_session _resolve_chat_session _gh_repo_name
 	)"
 }
 
@@ -30,68 +37,84 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "_parse_issue_chat_args: captures issue number from positional arg" {
-	local number="" description=""
-	_parse_issue_chat_args number description 42
+	local number="" description="" reset=""
+	_parse_issue_chat_args number description reset 42
 
 	[[ "$number" == "42" ]]
 	[[ -z "$description" ]]
+	[[ -z "$reset" ]]
 }
 
 @test "_parse_issue_chat_args: strips leading # from issue number" {
-	local number="" description=""
-	_parse_issue_chat_args number description "#42"
+	local number="" description="" reset=""
+	_parse_issue_chat_args number description reset "#42"
 
 	[[ "$number" == "42" ]]
 }
 
 @test "_parse_issue_chat_args: sets description from -d flag" {
-	local number="" description=""
-	_parse_issue_chat_args number description 42 -d "focus on auth"
+	local number="" description="" reset=""
+	_parse_issue_chat_args number description reset 42 -d "focus on auth"
 
 	[[ "$number" == "42" ]]
 	[[ "$description" == "focus on auth" ]]
 }
 
 @test "_parse_issue_chat_args: sets description from --description flag" {
-	local number="" description=""
-	_parse_issue_chat_args number description 42 --description "focus on auth"
+	local number="" description="" reset=""
+	_parse_issue_chat_args number description reset 42 --description "focus on auth"
 
 	[[ "$description" == "focus on auth" ]]
 }
 
 @test "_parse_issue_chat_args: sets description from --description=value" {
-	local number="" description=""
-	_parse_issue_chat_args number description 42 --description="focus on auth"
+	local number="" description="" reset=""
+	_parse_issue_chat_args number description reset 42 --description="focus on auth"
 
 	[[ "$description" == "focus on auth" ]]
 }
 
+@test "_parse_issue_chat_args: captures --reset flag" {
+	local number="" description="" reset=""
+	_parse_issue_chat_args number description reset 42 --reset
+
+	[[ "$number" == "42" ]]
+	[[ "$reset" == "1" ]]
+}
+
+@test "_parse_issue_chat_args: --reset defaults to empty" {
+	local number="" description="" reset=""
+	_parse_issue_chat_args number description reset 42
+
+	[[ -z "$reset" ]]
+}
+
 @test "_parse_issue_chat_args: returns error when -d has no value" {
-	local number="" description=""
-	run _parse_issue_chat_args number description 42 -d
+	local number="" description="" reset=""
+	run _parse_issue_chat_args number description reset 42 -d
 
 	[[ "$status" -eq 1 ]]
 }
 
 @test "_parse_issue_chat_args: returns error for unknown flags" {
-	local number="" description=""
-	run _parse_issue_chat_args number description --draft
+	local number="" description="" reset=""
+	run _parse_issue_chat_args number description reset --draft
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unknown flag '--draft'"* ]]
 }
 
 @test "_parse_issue_chat_args: returns error for unexpected non-numeric args" {
-	local number="" description=""
-	run _parse_issue_chat_args number description foo
+	local number="" description="" reset=""
+	run _parse_issue_chat_args number description reset foo
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unexpected argument 'foo'"* ]]
 }
 
 @test "_parse_issue_chat_args: returns error for second positional arg" {
-	local number="" description=""
-	run _parse_issue_chat_args number description 42 99
+	local number="" description="" reset=""
+	run _parse_issue_chat_args number description reset 42 99
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unexpected argument '99'"* ]]
@@ -116,6 +139,7 @@ setup() {
 _setup_chat_mocks() {
 	gh() {
 		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
 		"issue view") printf "gh_issue_title='Test Issue'\ngh_issue_body='Issue body'\ngh_issue_labels=''\ngh_issue_comments=''" ;;
 		"config get") ;;
 		esac
@@ -135,7 +159,7 @@ _setup_chat_mocks() {
 	export -f gum
 }
 
-@test "_gh_issue_chat: calls _cmd_chat with rendered preamble" {
+@test "_gh_issue_chat: calls _cmd_chat with rendered preamble and session args" {
 	_setup_chat_mocks
 
 	# Mock _cmd_chat to capture what it receives
@@ -150,21 +174,24 @@ _setup_chat_mocks() {
 	[[ "$status" -eq 0 ]]
 	[[ "$output" == *"PREAMBLE:"* ]]
 	[[ "$output" == *"Test Issue"* ]]
+	[[ "$output" == *"--session-id"* ]]
+	[[ "$output" == *"--worktree issue-42"* ]]
 }
 
-@test "_gh_issue_chat: passes args after -- to _cmd_chat" {
+@test "_gh_issue_chat: passes session args before passthrough args" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
 		printf 'PREAMBLE:%s\n' "$1"
 		shift
-		printf 'PASSTHROUGH:%s\n' "$*"
+		printf 'ALLARGS:%s\n' "$*"
 	}
 
 	run _gh_issue_chat 42 -- --model sonnet
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"PASSTHROUGH:--model sonnet"* ]]
+	[[ "$output" == *"--session-id"* ]]
+	[[ "$output" == *"--model sonnet"* ]]
 }
 
 @test "_gh_issue_chat: errors when no issue number provided" {
@@ -178,6 +205,7 @@ _setup_chat_mocks() {
 @test "_gh_issue_chat: errors when issue fetch fails" {
 	gh() {
 		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
 		"issue view") ;;
 		"config get") ;;
 		esac
@@ -199,6 +227,33 @@ _setup_chat_mocks() {
 	run _gh_issue_chat 42
 
 	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_issue_chat: resumes session without fetching metadata on second call" {
+	_setup_chat_mocks
+
+	_cmd_chat() {
+		printf 'PREAMBLE:%s\n' "$1"
+		shift
+		printf 'ARGS:%s\n' "$*"
+	}
+
+	# First call creates session
+	run _gh_issue_chat 42
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--session-id"* ]]
+
+	# Second call should resume with empty preamble
+	_cmd_chat() {
+		printf 'PREAMBLE:%s\n' "$1"
+		shift
+		printf 'ARGS:%s\n' "$*"
+	}
+
+	run _gh_issue_chat 42
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--resume"* ]]
+	[[ "$output" != *"Test Issue"* ]]
 }
 
 @test "_gh_issue_chat: shows help with --help flag" {

--- a/tests/gh_issue_plan.bats
+++ b/tests/gh_issue_plan.bats
@@ -21,7 +21,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_issue.sh"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _parse_issue_plan_args _show_issue_plan_help _gh_issue_plan _get_title _get_body
+		declare -f _parse_issue_plan_args _show_issue_plan_help _gh_issue_plan _parse_title _parse_body
 	)"
 }
 

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -9,10 +9,16 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
+	export HOME="$BATS_TEST_TMPDIR"
 
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
-	git() { echo ""; }
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$BATS_TEST_TMPDIR" ;;
+		"rev-parse --abbrev-ref") echo "" ;;
+		esac
+	}
 	export -f gum gh git
 
 	# shellcheck disable=SC2155
@@ -22,7 +28,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_pr.sh
 		source "$REPO_ROOT/scripts/gh_pr.sh"
-		declare -f _parse_pr_chat_args _show_pr_chat_help _gh_pr_chat _cmd_chat _cmd_render _split_on_separator _get_agent
+		declare -f _parse_pr_chat_args _show_pr_chat_help _gh_pr_chat _cmd_chat _cmd_render _split_on_separator _get_agent _uuidv5 _git_repo_path _resolve_session_state _try_resume_chat_session _resolve_chat_session _gh_repo_name
 	)"
 }
 
@@ -31,68 +37,84 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "_parse_pr_chat_args: captures PR number from positional arg" {
-	local number="" description=""
-	_parse_pr_chat_args number description 42
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset 42
 
 	[[ "$number" == "42" ]]
 	[[ -z "$description" ]]
+	[[ -z "$reset" ]]
 }
 
 @test "_parse_pr_chat_args: strips leading # from PR number" {
-	local number="" description=""
-	_parse_pr_chat_args number description "#42"
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset "#42"
 
 	[[ "$number" == "42" ]]
 }
 
 @test "_parse_pr_chat_args: sets description from -d flag" {
-	local number="" description=""
-	_parse_pr_chat_args number description 42 -d "focus on security"
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset 42 -d "focus on security"
 
 	[[ "$number" == "42" ]]
 	[[ "$description" == "focus on security" ]]
 }
 
 @test "_parse_pr_chat_args: sets description from --description flag" {
-	local number="" description=""
-	_parse_pr_chat_args number description 42 --description "focus on security"
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset 42 --description "focus on security"
 
 	[[ "$description" == "focus on security" ]]
 }
 
 @test "_parse_pr_chat_args: sets description from --description=value" {
-	local number="" description=""
-	_parse_pr_chat_args number description 42 --description="focus on security"
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset 42 --description="focus on security"
 
 	[[ "$description" == "focus on security" ]]
 }
 
+@test "_parse_pr_chat_args: captures --reset flag" {
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset 42 --reset
+
+	[[ "$number" == "42" ]]
+	[[ "$reset" == "1" ]]
+}
+
+@test "_parse_pr_chat_args: --reset defaults to empty" {
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset 42
+
+	[[ -z "$reset" ]]
+}
+
 @test "_parse_pr_chat_args: returns error when -d has no value" {
-	local number="" description=""
-	run _parse_pr_chat_args number description 42 -d
+	local number="" description="" reset=""
+	run _parse_pr_chat_args number description reset 42 -d
 
 	[[ "$status" -eq 1 ]]
 }
 
 @test "_parse_pr_chat_args: returns error for unknown flags" {
-	local number="" description=""
-	run _parse_pr_chat_args number description --draft
+	local number="" description="" reset=""
+	run _parse_pr_chat_args number description reset --draft
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unknown flag '--draft'"* ]]
 }
 
 @test "_parse_pr_chat_args: returns error for unexpected non-numeric args" {
-	local number="" description=""
-	run _parse_pr_chat_args number description foo
+	local number="" description="" reset=""
+	run _parse_pr_chat_args number description reset foo
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unexpected argument 'foo'"* ]]
 }
 
 @test "_parse_pr_chat_args: returns error for second positional arg" {
-	local number="" description=""
-	run _parse_pr_chat_args number description 42 99
+	local number="" description="" reset=""
+	run _parse_pr_chat_args number description reset 42 99
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unexpected argument '99'"* ]]
@@ -106,8 +128,8 @@ setup() {
 	}
 	export -f gh
 
-	local number="" description=""
-	_parse_pr_chat_args number description
+	local number="" description="" reset=""
+	_parse_pr_chat_args number description reset
 
 	[[ "$number" == "7" ]]
 }
@@ -131,8 +153,9 @@ setup() {
 _setup_chat_mocks() {
 	gh() {
 		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
 		"pr diff") echo "diff --git a/file.txt b/file.txt" ;;
-		"pr view") echo "Test PR Title" ;;
+		"pr view") printf "gh_pr_title='Test PR Title'\ngh_pr_body='PR body'\ngh_pr_head='feature-branch'\ngh_pr_commits='- Test commit'" ;;
 		"config get") ;;
 		esac
 	}
@@ -140,6 +163,8 @@ _setup_chat_mocks() {
 
 	git() {
 		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$BATS_TEST_TMPDIR" ;;
+		"rev-parse --abbrev-ref") echo "" ;;
 		"apply --stat") echo " file.txt | 1 +" ;;
 		*) ;;
 		esac
@@ -159,7 +184,7 @@ _setup_chat_mocks() {
 	export -f gum
 }
 
-@test "_gh_pr_chat: calls _cmd_chat with rendered preamble" {
+@test "_gh_pr_chat: calls _cmd_chat with rendered preamble and session args" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
@@ -172,21 +197,24 @@ _setup_chat_mocks() {
 
 	[[ "$status" -eq 0 ]]
 	[[ "$output" == *"PREAMBLE:"* ]]
+	[[ "$output" == *"--session-id"* ]]
+	[[ "$output" == *"--worktree pull-42"* ]]
 }
 
-@test "_gh_pr_chat: passes args after -- to _cmd_chat" {
+@test "_gh_pr_chat: passes session args before passthrough args" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
 		printf 'PREAMBLE:%s\n' "$1"
 		shift
-		printf 'PASSTHROUGH:%s\n' "$*"
+		printf 'ALLARGS:%s\n' "$*"
 	}
 
 	run _gh_pr_chat 42 -- --model sonnet
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"PASSTHROUGH:--model sonnet"* ]]
+	[[ "$output" == *"--session-id"* ]]
+	[[ "$output" == *"--model sonnet"* ]]
 }
 
 @test "_gh_pr_chat: errors when no PR number provided" {
@@ -218,6 +246,7 @@ _setup_chat_mocks() {
 @test "_gh_pr_chat: errors when diff is empty" {
 	gh() {
 		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
 		"pr diff") ;;
 		"pr view") echo "Test PR Title" ;;
 		"config get") ;;
@@ -240,6 +269,36 @@ _setup_chat_mocks() {
 	run _gh_pr_chat 42
 
 	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_pr_chat: resumes session without fetching metadata on second call" {
+	_setup_chat_mocks
+
+	local fetch_count=0
+	_cmd_chat() {
+		printf 'PREAMBLE:%s\n' "$1"
+		shift
+		printf 'ARGS:%s\n' "$*"
+	}
+
+	# First call creates session
+	run _gh_pr_chat 42
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--session-id"* ]]
+
+	# Second call should resume with empty preamble
+	_cmd_chat() {
+		printf 'PREAMBLE:%s\n' "$1"
+		shift
+		printf 'ARGS:%s\n' "$*"
+	}
+
+	run _gh_pr_chat 42
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--resume"* ]]
+	[[ "$output" == *"PREAMBLE:"* ]]
+	# Preamble should be empty on resume
+	[[ "$output" != *"Test PR Title"* ]]
 }
 
 @test "_gh_pr_chat: shows help with --help flag" {

--- a/tests/gh_pr_create.bats
+++ b/tests/gh_pr_create.bats
@@ -22,7 +22,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_pr.sh
 		source "$REPO_ROOT/scripts/gh_pr.sh"
-		declare -f _parse_pr_create_args _show_pr_create_help _gh_pr_create _split_on_separator
+		declare -f _parse_pr_create_args _show_pr_create_help _gh_pr_create _split_on_separator _git_branch_diff
 	)"
 }
 

--- a/tests/gh_run_chat.bats
+++ b/tests/gh_run_chat.bats
@@ -9,10 +9,17 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 
 setup() {
 	export _gh_ai_source_dir="$REPO_ROOT"
+	export HOME="$BATS_TEST_TMPDIR"
 
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
-	export -f gum gh
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$BATS_TEST_TMPDIR" ;;
+		"rev-parse --abbrev-ref") echo "" ;;
+		esac
+	}
+	export -f gum gh git
 
 	# shellcheck disable=SC2155
 	eval "$(
@@ -21,7 +28,7 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_run.sh"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _parse_run_chat_args _show_run_chat_help _gh_run_chat _cmd_chat _cmd_render _split_on_separator _get_agent
+		declare -f _parse_run_chat_args _show_run_chat_help _gh_run_chat _cmd_chat _cmd_render _split_on_separator _get_agent _uuidv5 _git_repo_path _resolve_session_state _try_resume_chat_session _resolve_chat_session _gh_repo_name
 	)"
 }
 
@@ -30,76 +37,92 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "_parse_run_chat_args: captures run ID from positional arg" {
-	local id="" description=""
-	_parse_run_chat_args id description 12345678
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset 12345678
 
 	[[ "$id" == "12345678" ]]
 	[[ -z "$description" ]]
+	[[ -z "$reset" ]]
 }
 
 @test "_parse_run_chat_args: strips leading # from run ID" {
-	local id="" description=""
-	_parse_run_chat_args id description "#12345678"
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset "#12345678"
 
 	[[ "$id" == "12345678" ]]
 }
 
 @test "_parse_run_chat_args: sets description from -d flag" {
-	local id="" description=""
-	_parse_run_chat_args id description 12345678 -d "focus on test failures"
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset 12345678 -d "focus on test failures"
 
 	[[ "$id" == "12345678" ]]
 	[[ "$description" == "focus on test failures" ]]
 }
 
 @test "_parse_run_chat_args: sets description from --description flag" {
-	local id="" description=""
-	_parse_run_chat_args id description 12345678 --description "focus on test failures"
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset 12345678 --description "focus on test failures"
 
 	[[ "$description" == "focus on test failures" ]]
 }
 
 @test "_parse_run_chat_args: sets description from --description=value" {
-	local id="" description=""
-	_parse_run_chat_args id description 12345678 --description="focus on test failures"
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset 12345678 --description="focus on test failures"
 
 	[[ "$description" == "focus on test failures" ]]
 }
 
+@test "_parse_run_chat_args: captures --reset flag" {
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset 12345678 --reset
+
+	[[ "$id" == "12345678" ]]
+	[[ "$reset" == "1" ]]
+}
+
+@test "_parse_run_chat_args: --reset defaults to empty" {
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset 12345678
+
+	[[ -z "$reset" ]]
+}
+
 @test "_parse_run_chat_args: returns error when -d has no value" {
-	local id="" description=""
-	run _parse_run_chat_args id description 12345678 -d
+	local id="" description="" reset=""
+	run _parse_run_chat_args id description reset 12345678 -d
 
 	[[ "$status" -eq 1 ]]
 }
 
 @test "_parse_run_chat_args: returns error for unknown flags" {
-	local id="" description=""
-	run _parse_run_chat_args id description --failed
+	local id="" description="" reset=""
+	run _parse_run_chat_args id description reset --failed
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unknown flag '--failed'"* ]]
 }
 
 @test "_parse_run_chat_args: returns error for unexpected non-numeric arg" {
-	local id="" description=""
-	run _parse_run_chat_args id description foo
+	local id="" description="" reset=""
+	run _parse_run_chat_args id description reset foo
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unexpected argument 'foo'"* ]]
 }
 
 @test "_parse_run_chat_args: returns error for second positional arg" {
-	local id="" description=""
-	run _parse_run_chat_args id description 12345678 99999999
+	local id="" description="" reset=""
+	run _parse_run_chat_args id description reset 12345678 99999999
 
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *"unexpected argument '99999999'"* ]]
 }
 
 @test "_parse_run_chat_args: defaults to empty when no args given" {
-	local id="" description=""
-	_parse_run_chat_args id description
+	local id="" description="" reset=""
+	_parse_run_chat_args id description reset
 
 	[[ -z "$id" ]]
 }
@@ -123,7 +146,8 @@ setup() {
 _setup_chat_mocks() {
 	gh() {
 		case "$1 $2" in
-		"run view") printf "gh_run_title='Test Run'\ngh_run_conclusion='failure'\ngh_run_url='https://github.com/owner/repo/actions/runs/123'\ngh_run_event='push'\ngh_run_branch='main'\ngh_run_jobs='build'" ;;
+		"repo view") echo "owner/repo" ;;
+		"run view") printf "gh_run_title='Test Run'\ngh_run_conclusion='failure'\ngh_run_event='push'\ngh_run_branch='main'\ngh_run_jobs='build'" ;;
 		"config get") ;;
 		esac
 	}
@@ -142,7 +166,7 @@ _setup_chat_mocks() {
 	export -f gum
 }
 
-@test "_gh_run_chat: calls _cmd_chat with rendered preamble" {
+@test "_gh_run_chat: calls _cmd_chat with rendered preamble and session args" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
@@ -156,21 +180,24 @@ _setup_chat_mocks() {
 	[[ "$status" -eq 0 ]]
 	[[ "$output" == *"PREAMBLE:"* ]]
 	[[ "$output" == *"Test Run"* ]]
+	[[ "$output" == *"--session-id"* ]]
+	[[ "$output" == *"--worktree run-12345678"* ]]
 }
 
-@test "_gh_run_chat: passes args after -- to _cmd_chat" {
+@test "_gh_run_chat: passes session args before passthrough args" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
 		printf 'PREAMBLE:%s\n' "$1"
 		shift
-		printf 'PASSTHROUGH:%s\n' "$*"
+		printf 'ALLARGS:%s\n' "$*"
 	}
 
 	run _gh_run_chat 12345678 -- --model sonnet
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"PASSTHROUGH:--model sonnet"* ]]
+	[[ "$output" == *"--session-id"* ]]
+	[[ "$output" == *"--model sonnet"* ]]
 }
 
 @test "_gh_run_chat: errors when no run ID provided" {
@@ -184,6 +211,7 @@ _setup_chat_mocks() {
 @test "_gh_run_chat: errors when metadata fetch fails" {
 	gh() {
 		case "$1 $2" in
+		"repo view") echo "owner/repo" ;;
 		"run view") ;;
 		"config get") ;;
 		esac
@@ -205,6 +233,33 @@ _setup_chat_mocks() {
 	run _gh_run_chat 12345678
 
 	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_run_chat: resumes session without fetching metadata on second call" {
+	_setup_chat_mocks
+
+	_cmd_chat() {
+		printf 'PREAMBLE:%s\n' "$1"
+		shift
+		printf 'ARGS:%s\n' "$*"
+	}
+
+	# First call creates session
+	run _gh_run_chat 12345678
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--session-id"* ]]
+
+	# Second call should resume with empty preamble
+	_cmd_chat() {
+		printf 'PREAMBLE:%s\n' "$1"
+		shift
+		printf 'ARGS:%s\n' "$*"
+	}
+
+	run _gh_run_chat 12345678
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--resume"* ]]
+	[[ "$output" != *"Test Run"* ]]
 }
 
 @test "_gh_run_chat: shows help with --help flag" {

--- a/tests/gh_session.bats
+++ b/tests/gh_session.bats
@@ -1,0 +1,266 @@
+#!/usr/bin/env bats
+
+# Unit tests for _resolve_chat_session in gh_cmd.sh
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_session.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+	export HOME="$BATS_TEST_TMPDIR"
+
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$BATS_TEST_TMPDIR" ;;
+		"rev-parse --abbrev-ref") echo "" ;;
+		esac
+	}
+	export -f gum git
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		declare -f _uuidv5 _git_repo_path _resolve_session_state _try_resume_chat_session _resolve_chat_session
+	)"
+}
+
+# ---------------------------------------------------------------------------
+# _try_resume_chat_session
+# ---------------------------------------------------------------------------
+
+@test "_try_resume_chat_session: returns 1 when no state file exists" {
+	local args=()
+	run _try_resume_chat_session args "https://github.com/owner/repo/issues/42" ""
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_try_resume_chat_session: returns 0 when state file exists" {
+	# Create state file first via _resolve_chat_session
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local resume_args=()
+	_try_resume_chat_session resume_args "https://github.com/owner/repo/issues/42" ""
+
+	[[ ${#resume_args[@]} -eq 4 ]]
+	[[ "${resume_args[0]}" == "--resume" ]]
+	[[ "${resume_args[1]}" == "${args[1]}" ]]
+	[[ "${resume_args[2]}" == "--worktree" ]]
+	[[ "${resume_args[3]}" == "issue-42" ]]
+}
+
+@test "_try_resume_chat_session: returns 1 after --reset deletes state file" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local resume_args=()
+	if _try_resume_chat_session resume_args "https://github.com/owner/repo/issues/42" "1"; then
+		return 1
+	fi
+
+	[[ ${#resume_args[@]} -eq 0 ]]
+}
+
+@test "_try_resume_chat_session: returns 1 when URL is empty" {
+	local args=()
+	if _try_resume_chat_session args "" ""; then
+		return 1
+	fi
+
+	[[ ${#args[@]} -eq 0 ]]
+}
+
+@test "_try_resume_chat_session: returns 1 when user passes --resume in passthrough" {
+	# Create state file first
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local resume_args=()
+	if _try_resume_chat_session resume_args "https://github.com/owner/repo/issues/42" "" --resume "custom-id"; then
+		return 1
+	fi
+
+	[[ ${#resume_args[@]} -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _resolve_chat_session
+# ---------------------------------------------------------------------------
+
+@test "_resolve_chat_session: first call returns --session-id and --worktree" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	[[ ${#args[@]} -eq 4 ]]
+	[[ "${args[0]}" == "--session-id" ]]
+	[[ -n "${args[1]}" ]]
+	[[ "${args[2]}" == "--worktree" ]]
+	[[ "${args[3]}" == "issue-42" ]]
+}
+
+@test "_resolve_chat_session: creates state file on first call" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local session_id="${args[1]}"
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${session_id}.json"
+	[[ -f "$state_file" ]]
+}
+
+@test "_resolve_chat_session: second call returns --resume with same session ID" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local first_id="${args[1]}"
+
+	local args2=()
+	_resolve_chat_session args2 "https://github.com/owner/repo/issues/42" "" ""
+
+	[[ ${#args2[@]} -eq 4 ]]
+	[[ "${args2[0]}" == "--resume" ]]
+	[[ "${args2[1]}" == "$first_id" ]]
+	[[ "${args2[2]}" == "--worktree" ]]
+	[[ "${args2[3]}" == "issue-42" ]]
+}
+
+@test "_resolve_chat_session: --reset deletes existing state and returns --session-id" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local args2=()
+	_resolve_chat_session args2 "https://github.com/owner/repo/issues/42" "1" ""
+
+	[[ ${#args2[@]} -eq 4 ]]
+	[[ "${args2[0]}" == "--session-id" ]]
+	[[ "${args2[2]}" == "--worktree" ]]
+}
+
+@test "_resolve_chat_session: skips when user passes --resume in passthrough" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" "" --resume "some-uuid"
+
+	[[ ${#args[@]} -eq 0 ]]
+}
+
+@test "_resolve_chat_session: skips when user passes --session-id in passthrough" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" "" --session-id "some-uuid"
+
+	[[ ${#args[@]} -eq 0 ]]
+}
+
+@test "_resolve_chat_session: skips when user passes --continue in passthrough" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" "" --continue
+
+	[[ ${#args[@]} -eq 0 ]]
+}
+
+@test "_resolve_chat_session: skips when user passes -c in passthrough" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" "" -c
+
+	[[ ${#args[@]} -eq 0 ]]
+}
+
+@test "_resolve_chat_session: skips silently when URL is empty" {
+	local args=()
+	_resolve_chat_session args "" "" ""
+
+	[[ ${#args[@]} -eq 0 ]]
+}
+
+@test "_resolve_chat_session: all resource types use sessions/ directory" {
+	local args_issue=() args_pr=() args_run=()
+	_resolve_chat_session args_issue "https://github.com/owner/repo/issues/42" "" ""
+	_resolve_chat_session args_pr "https://github.com/owner/repo/pull/7" "" ""
+	_resolve_chat_session args_run "https://github.com/owner/repo/actions/runs/123456" "" ""
+
+	local sessions_dir="$BATS_TEST_TMPDIR/.claude/sessions"
+	[[ -f "$sessions_dir/${args_issue[1]}.json" ]]
+	[[ -f "$sessions_dir/${args_pr[1]}.json" ]]
+	[[ -f "$sessions_dir/${args_run[1]}.json" ]]
+}
+
+@test "_resolve_chat_session: state file contains valid session_id and name" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local content
+	content=$(cat "$state_file")
+
+	[[ "$content" == *'"session_id"'* ]]
+	[[ "$content" == *'"name"'* ]]
+	[[ "$content" == *"issue-42"* ]]
+}
+
+@test "_resolve_chat_session: derives worktree name from URL segments" {
+	local args=()
+
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+	[[ "${args[3]}" == "issue-42" ]]
+
+	args=()
+	_resolve_chat_session args "https://github.com/owner/repo/pull/7" "" ""
+	[[ "${args[3]}" == "pull-7" ]]
+
+	args=()
+	_resolve_chat_session args "https://github.com/owner/repo/actions/runs/123456" "" ""
+	[[ "${args[3]}" == "run-123456" ]]
+}
+
+@test "_resolve_chat_session: state file contains remote_ref when provided" {
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/pull/7" "" "feat-my-branch"
+
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local content
+	content=$(cat "$state_file")
+
+	[[ "$content" == *'"remote_ref": "feat-my-branch"'* ]]
+}
+
+@test "_resolve_chat_session: state file contains default remote_ref when not provided" {
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$BATS_TEST_TMPDIR" ;;
+		"rev-parse --abbrev-ref") echo "origin/develop" ;;
+		esac
+	}
+	export -f git
+
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local content
+	content=$(cat "$state_file")
+
+	[[ "$content" == *'"remote_ref": "develop"'* ]]
+}
+
+@test "_resolve_chat_session: remote_ref defaults to main when git rev-parse fails" {
+	git() {
+		case "$1 $2" in
+		"rev-parse --show-toplevel") echo "$BATS_TEST_TMPDIR" ;;
+		"rev-parse --abbrev-ref") return 1 ;;
+		esac
+	}
+	export -f git
+
+	local args=()
+	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
+
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local content
+	content=$(cat "$state_file")
+
+	[[ "$content" == *'"remote_ref": "main"'* ]]
+}


### PR DESCRIPTION
## Summary

- Add `_uuidv5` (pure bash, zero dependencies) and `_resolve_chat_session` to `gh_cmd.sh` for deterministic session ID generation and state file management
- Add `--reset` flag to all three chat command parsers (`issue`, `pr`, `run`) to allow forcing a new session
- Wire `_resolve_chat_session` into `_gh_issue_chat`, `_gh_pr_chat`, and `_gh_run_chat` so session args are injected before passthrough args
- Create `tests/gh_session.bats` with 12 tests covering first-call, resume, reset, skip conditions, and state file paths
- Add 5 `_uuidv5` tests to `tests/gh_cmd.bats` verified against python3 `uuid.uuid5()` constants
- Add `--reset` parser tests and update integration tests across all three chat test files

Closes #35

## Test plan

- [x] All 185 tests pass (`npx bats tests/`)
- [x] Smoke test: `gh ai issue chat <number>` — first run shows `--session-id` + `--worktree`
- [x] Smoke test: `gh ai issue chat <number>` — second run resumes
- [x] Smoke test: `gh ai issue chat <number> --reset` — resets session
- [x] Smoke test: `gh ai issue chat <number> -- --resume <uuid>` — session management skipped