### PR TITLE
feat: add safe worktree removal with auto-stash and unpushed warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,18 @@ Chat commands automatically persist sessions per resource. The first
 invocation creates a new session with a dedicated worktree; subsequent runs
 resume it. Session state is stored in the repository at:
 
-```
+```text
 <repo-root>/.claude/sessions/<session-uuid>.json
 ```
 
 Use `--new-session` (or `-n`) to discard the existing session and start fresh. Session
 management is skipped when you pass your own `--resume`, `--session-id`,
 `--continue`, or `-c` after `--`.
+
+When a session ends, the worktree is automatically removed. If the worktree
+has uncommitted changes, they are auto-stashed before removal so nothing is
+lost. Recover them with `git stash list` and look for entries prefixed with
+`gh-ai: auto-stash worktree`. Unpushed commits remain in the branch reflog.
 
 ## Configuration
 

--- a/scripts/gh_worktree.sh
+++ b/scripts/gh_worktree.sh
@@ -46,27 +46,84 @@ _gh_worktree_create() {
 	printf '%s\n' "$gh_worktree_path"
 }
 
+# Check if a worktree has uncommitted changes (untracked, modified, staged)
+#
+# Returns 0 if dirty, 1 if clean.
+#
+# Usage: _gh_worktree_is_dirty "/path/to/worktree"
+_gh_worktree_is_dirty() {
+	local wt="$1"
+	[[ -n "$(git -C "$wt" status --porcelain 2>/dev/null)" ]]
+}
+
+# Check if a worktree has commits not pushed to the upstream branch
+#
+# Returns 0 if there are unpushed commits, 1 otherwise.
+# Falls back to clean when there is no upstream configured.
+#
+# Usage: _gh_worktree_has_unpushed "/path/to/worktree"
+_gh_worktree_has_unpushed() {
+	local wt="$1"
+	local ahead
+	ahead=$(git -C "$wt" rev-list --count '@{upstream}..HEAD' 2>/dev/null || echo "0")
+	[[ "$ahead" -gt 0 ]]
+}
+
 # Remove a git worktree created by _gh_worktree_create
 #
-# Reads JSON from stdin with "worktree_path" field and force-removes
-# the worktree. Silently succeeds if the path does not exist.
+# Reads JSON from stdin with "worktree_path" field. Before removing,
+# checks for uncommitted or unpushed changes. If found, auto-stashes
+# them so they are recoverable from the main repo via `git stash list`.
+#
+# WorktreeRemove hooks have no decision control and cannot be
+# interactive — they run as cleanup side effects. Auto-stash is the
+# safest non-interactive strategy to prevent silent data loss.
+#
+# Silently removes clean worktrees.
+# Silently succeeds if the worktree path does not exist.
 #
 # Stdin: {"worktree_path": "/path/to/repo/.claude/worktrees/issue-42"}
 _gh_worktree_remove() {
 	local worktree_path
 	worktree_path=$(jq -r .worktree_path)
-	git worktree remove -f "$worktree_path" 2>/dev/null || true
+
+	# Nothing to do if the worktree doesn't exist
+	if [[ ! -d "$worktree_path" ]]; then
+		return 0
+	fi
+
+	# Auto-stash dirty changes so they survive worktree removal
+	if _gh_worktree_is_dirty "$worktree_path"; then
+		local wt_name
+		wt_name=$(basename "$worktree_path")
+		# Stage everything (including untracked) so stash captures it all
+		git -C "$worktree_path" add -A
+		git -C "$worktree_path" stash push -m "gh-ai: auto-stash worktree '${wt_name}'" 2>/dev/null || true
+		echo "Auto-stashed uncommitted changes from worktree '${wt_name}' — recover with: git stash list" >&2
+	fi
+
+	# Warn about unpushed commits (stash doesn't help here — they're in the branch reflog)
+	if _gh_worktree_has_unpushed "$worktree_path"; then
+		local branch
+		branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+		echo "Warning: branch '${branch}' has unpushed commits — they remain in the reflog" >&2
+	fi
+
+	git -C "$worktree_path" worktree remove -f "$worktree_path" 2>/dev/null || true
 }
 
-case "${1:-}" in
-create)
-	_gh_worktree_create
-	;;
-remove)
-	_gh_worktree_remove
-	;;
-*)
-	echo "Usage: gh_worktree.sh <create|remove>" >&2
-	exit 1
-	;;
-esac
+# CLI entry point (when executed directly, not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	case "${1:-}" in
+	create)
+		_gh_worktree_create
+		;;
+	remove)
+		_gh_worktree_remove
+		;;
+	*)
+		echo "Usage: gh_worktree.sh <create|remove>" >&2
+		exit 1
+		;;
+	esac
+fi

--- a/tests/gh_worktree.bats
+++ b/tests/gh_worktree.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh_worktree.sh
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_worktree.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+	export HOME="$BATS_TEST_TMPDIR"
+
+	# Create a bare "remote" and a worktree-like local clone
+	git init --bare "$BATS_TEST_TMPDIR/remote.git" >/dev/null 2>&1
+	git clone "$BATS_TEST_TMPDIR/remote.git" "$BATS_TEST_TMPDIR/repo" >/dev/null 2>&1
+	git -C "$BATS_TEST_TMPDIR/repo" commit --allow-empty -m "initial" >/dev/null 2>&1
+	git -C "$BATS_TEST_TMPDIR/repo" push >/dev/null 2>&1
+
+	# Create a worktree off the clone
+	WORKTREE_PATH="$BATS_TEST_TMPDIR/repo/.claude/worktrees/issue-1"
+	git -C "$BATS_TEST_TMPDIR/repo" worktree add -B worktree-issue-1 "$WORKTREE_PATH" HEAD >/dev/null 2>&1
+	git -C "$WORKTREE_PATH" branch --set-upstream-to=origin/main >/dev/null 2>&1
+
+	# Source the functions under test
+	# shellcheck disable=SC2155
+	eval "$(
+		# shellcheck source=../scripts/gh_worktree.sh
+		source "$REPO_ROOT/scripts/gh_worktree.sh"
+		declare -f _gh_worktree_is_dirty _gh_worktree_has_unpushed _gh_worktree_remove
+	)"
+}
+
+teardown() {
+	# Clean up worktrees so git doesn't complain
+	git -C "$BATS_TEST_TMPDIR/repo" worktree prune 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# _gh_worktree_is_dirty
+# ---------------------------------------------------------------------------
+
+@test "_gh_worktree_is_dirty: returns 1 for clean worktree" {
+	run _gh_worktree_is_dirty "$WORKTREE_PATH"
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_worktree_is_dirty: returns 0 for untracked file" {
+	echo "new" >"$WORKTREE_PATH/untracked.txt"
+
+	run _gh_worktree_is_dirty "$WORKTREE_PATH"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "_gh_worktree_is_dirty: returns 0 for staged changes" {
+	echo "staged" >"$WORKTREE_PATH/staged.txt"
+	git -C "$WORKTREE_PATH" add staged.txt
+
+	run _gh_worktree_is_dirty "$WORKTREE_PATH"
+	[[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _gh_worktree_has_unpushed
+# ---------------------------------------------------------------------------
+
+@test "_gh_worktree_has_unpushed: returns 1 when up to date" {
+	run _gh_worktree_has_unpushed "$WORKTREE_PATH"
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_gh_worktree_has_unpushed: returns 0 when commits ahead" {
+	git -C "$WORKTREE_PATH" commit --allow-empty -m "local only" >/dev/null 2>&1
+
+	run _gh_worktree_has_unpushed "$WORKTREE_PATH"
+	[[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# _gh_worktree_remove
+# ---------------------------------------------------------------------------
+
+@test "_gh_worktree_remove: removes clean worktree silently" {
+	echo '{"worktree_path": "'"$WORKTREE_PATH"'"}' | _gh_worktree_remove
+
+	[[ ! -d "$WORKTREE_PATH" ]]
+}
+
+@test "_gh_worktree_remove: succeeds when worktree path does not exist" {
+	echo '{"worktree_path": "/nonexistent/path"}' | _gh_worktree_remove
+}
+
+@test "_gh_worktree_remove: auto-stashes uncommitted changes before removal" {
+	echo "save me" >"$WORKTREE_PATH/dirty.txt"
+
+	echo '{"worktree_path": "'"$WORKTREE_PATH"'"}' | _gh_worktree_remove
+
+	# Worktree should be removed
+	[[ ! -d "$WORKTREE_PATH" ]]
+
+	# Changes should be in the stash
+	local stash_list
+	stash_list=$(git -C "$BATS_TEST_TMPDIR/repo" stash list)
+	[[ "$stash_list" == *"gh-ai: auto-stash worktree 'issue-1'"* ]]
+}
+
+@test "_gh_worktree_remove: stash includes untracked files" {
+	echo "untracked" >"$WORKTREE_PATH/new_file.txt"
+
+	echo '{"worktree_path": "'"$WORKTREE_PATH"'"}' | _gh_worktree_remove
+
+	# Pop the stash into the main repo and verify the file is there
+	git -C "$BATS_TEST_TMPDIR/repo" stash pop >/dev/null 2>&1
+	[[ -f "$BATS_TEST_TMPDIR/repo/new_file.txt" ]]
+}
+
+@test "_gh_worktree_remove: warns about unpushed commits" {
+	git -C "$WORKTREE_PATH" commit --allow-empty -m "unpushed work" >/dev/null 2>&1
+
+	local output
+	output=$(echo '{"worktree_path": "'"$WORKTREE_PATH"'"}' | _gh_worktree_remove 2>&1)
+
+	# Worktree should be removed
+	[[ ! -d "$WORKTREE_PATH" ]]
+
+	# Should warn about unpushed commits
+	[[ "$output" == *"unpushed commits"* ]]
+}
+
+@test "_gh_worktree_remove: stashes and warns when both dirty and unpushed" {
+	echo "dirty" >"$WORKTREE_PATH/dirty.txt"
+	git -C "$WORKTREE_PATH" commit --allow-empty -m "unpushed" >/dev/null 2>&1
+
+	local output
+	output=$(echo '{"worktree_path": "'"$WORKTREE_PATH"'"}' | _gh_worktree_remove 2>&1)
+
+	[[ ! -d "$WORKTREE_PATH" ]]
+	[[ "$output" == *"auto-stash"*"issue-1"* ]]
+	[[ "$output" == *"unpushed commits"* ]]
+}
+
+@test "_gh_worktree_remove: does not stash when worktree is clean" {
+	echo '{"worktree_path": "'"$WORKTREE_PATH"'"}' | _gh_worktree_remove
+
+	local stash_list
+	stash_list=$(git -C "$BATS_TEST_TMPDIR/repo" stash list)
+	[[ -z "$stash_list" ]]
+}

--- a/tests/gh_worktree.bats
+++ b/tests/gh_worktree.bats
@@ -14,6 +14,8 @@ setup() {
 	# Create a bare "remote" and a worktree-like local clone
 	git init --bare "$BATS_TEST_TMPDIR/remote.git" >/dev/null 2>&1
 	git clone "$BATS_TEST_TMPDIR/remote.git" "$BATS_TEST_TMPDIR/repo" >/dev/null 2>&1
+	git -C "$BATS_TEST_TMPDIR/repo" config user.email "test@test.com"
+	git -C "$BATS_TEST_TMPDIR/repo" config user.name "Test"
 	git -C "$BATS_TEST_TMPDIR/repo" commit --allow-empty -m "initial" >/dev/null 2>&1
 	git -C "$BATS_TEST_TMPDIR/repo" push >/dev/null 2>&1
 

--- a/tests/gh_worktree.bats
+++ b/tests/gh_worktree.bats
@@ -22,7 +22,9 @@ setup() {
 	# Create a worktree off the clone
 	WORKTREE_PATH="$BATS_TEST_TMPDIR/repo/.claude/worktrees/issue-1"
 	git -C "$BATS_TEST_TMPDIR/repo" worktree add -B worktree-issue-1 "$WORKTREE_PATH" HEAD >/dev/null 2>&1
-	git -C "$WORKTREE_PATH" branch --set-upstream-to=origin/main >/dev/null 2>&1
+	local _main_branch
+	_main_branch=$(git -C "$BATS_TEST_TMPDIR/repo" rev-parse --abbrev-ref HEAD)
+	git -C "$WORKTREE_PATH" branch --set-upstream-to="origin/${_main_branch}" >/dev/null 2>&1
 
 	# Source the functions under test
 	# shellcheck disable=SC2155


### PR DESCRIPTION
Implement `_gh_worktree_is_dirty` and `_gh_worktree_has_unpushed` helper
functions to detect uncommitted changes and unpushed commits. Update
`_gh_worktree_remove` to auto-stash dirty changes before removal so they
remain recoverable via `git stash list`, and warn about unpushed commits
that survive in the branch reflog. Add comprehensive bats test suite
covering all removal scenarios. Update README to document the auto-stash
behavior and recovery instructions.
