### PR TITLE
Use file-backed template variables to bypass ARG_MAX limits

### DIFF
--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -30,13 +30,14 @@ _cmd_render() {
 	fi
 
 	awk '
-	function readfile(path,    content, line, first) {
-		content = ""; first = 1
-		while ((getline line < path) > 0) {
-			if (!first) content = content "\n"
-			content = content line; first = 0
+	function readfile(path,    content, line, cmd) {
+		content = ""
+		cmd = "cat " path
+		while ((cmd | getline line) > 0) {
+			if (content != "") content = content "\n"
+			content = content line
 		}
-		close(path)
+		close(cmd)
 		return content
 	}
 	{ content = content $0 "\n" }

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -11,12 +11,16 @@ set -euo pipefail
 # Reads the given template file and uses awk to replace ${VAR} tokens with the
 # values of the corresponding environment variables (via ENVIRON[]).
 #
+# File-backed variables: If ENVIRON[VAR] is empty but ENVIRON[VAR_FILE] is set,
+# reads the file content from that path. This allows large content to bypass ARG_MAX.
+#
 # Safety: substitution is a single left-to-right pass — values are never
 # re-scanned, so ${...} patterns inside a substituted value (e.g. in a git
 # diff) are never expanded. Template files use ALL_CAPS variable names
 # (GH_PR_DIFF, GH_ISSUE_*, etc.) that do not overlap with standard shell variables.
 #
 # Usage: MY_VAR="value" _cmd_render template.tmpl
+# Usage: GH_PR_DIFF_FILE="/tmp/diff.patch" _cmd_render template.tmpl
 _cmd_render() {
 	local template_file="$1"
 
@@ -26,12 +30,25 @@ _cmd_render() {
 	fi
 
 	awk '
+	function readfile(path,    content, line, first) {
+		content = ""; first = 1
+		while ((getline line < path) > 0) {
+			if (!first) content = content "\n"
+			content = content line; first = 0
+		}
+		close(path)
+		return content
+	}
 	{ content = content $0 "\n" }
 	END {
 		result = ""; remaining = content
 		while (match(remaining, /\$\{[A-Z_][A-Z0-9_]*\}/)) {
 			varname = substr(remaining, RSTART+2, RLENGTH-3)
-			result = result substr(remaining, 1, RSTART-1) ENVIRON[varname]
+			val = ENVIRON[varname]
+			if (val == "" && ENVIRON[varname "_FILE"] != "") {
+				val = readfile(ENVIRON[varname "_FILE"])
+			}
+			result = result substr(remaining, 1, RSTART-1) val
 			remaining = substr(remaining, RSTART+RLENGTH)
 		}
 		printf "%s%s", result, remaining
@@ -255,6 +272,27 @@ _git_branch_diff() {
 	_commits_ref=$(printf '%s\n' "$_log_ref" | sed 's/^[a-f0-9]* /- /')
 }
 
+# Create a temporary context directory for ask-mode commands
+#
+# Creates a temp directory that can hold large context files. Caller is
+# responsible for cleanup (rm -rf) after use.
+#
+# Usage: _create_context_dir context_dir_ref
+_create_context_dir() {
+	local -n _cdir_ref="$1"
+	_cdir_ref=$(mktemp -d "${TMPDIR:-/tmp}/gh-ai-ctx.XXXXXXXXXX")
+}
+
+# Save content to a named file in a context directory
+#
+# Writes content to a file using printf builtin (no execve, so no ARG_MAX impact).
+#
+# Usage: _save_context_file "/path/to/context/dir" "filename" "content"
+_save_context_file() {
+	local dir="$1" name="$2" content="$3"
+	printf '%s' "$content" > "$dir/$name"
+}
+
 # Generate a UUIDv5 from a name using the NAMESPACE_URL (RFC 4122)
 #
 # Pure bash implementation — uses printf for the 16-byte NAMESPACE_URL raw
@@ -314,10 +352,12 @@ _resolve_session_state() {
 	local git_root
 	_git_repo_path git_root || return 1
 
-	_ss_path="$git_root/.claude/sessions/${_ss_sid}.json"
+	_ss_path="$git_root/.claude/sessions/$_ss_sid"
 
-	if [[ -n "$new_session" && -f "$_ss_path" ]]; then
-		rm -f "$_ss_path"
+	if [[ -n "$new_session" ]]; then
+		# Clean up both old .json format and new directory format
+		rm -f "${_ss_path}.json"
+		rm -rf "$_ss_path"
 	fi
 }
 
@@ -340,7 +380,8 @@ _try_resume_chat_session() {
 	local session_id="" name="" state_file=""
 	_resolve_session_state session_id name state_file "$resource_url" "$new_session" "$@" || return 1
 
-	if [[ -f "$state_file" ]]; then
+	# Check for new directory format first, then fall back to old .json format
+	if [[ -d "$state_file" && -f "$state_file/state.json" ]] || [[ -f "${state_file}.json" ]]; then
 		_session_args_ref=(--resume "$session_id" --worktree "$name")
 		return 0
 	fi
@@ -374,9 +415,13 @@ _resolve_chat_session() {
 	local session_id="" name="" state_file=""
 	_resolve_session_state session_id name state_file "$resource_url" "$new_session" "$@" || return 0
 
-	mkdir -p "$(dirname "$state_file")"
+	# Create session directory
+	mkdir -p "$state_file"
 
-	if [[ -f "$state_file" ]]; then
+	local state_json="$state_file/state.json"
+
+	# Check both new and old formats for existing session
+	if [[ -f "$state_json" ]] || [[ -f "${state_file}.json" ]]; then
 		_session_args_ref=(--resume "$session_id" --worktree "$name")
 	else
 		# Default to the repository's default branch when no remote ref is provided
@@ -385,7 +430,7 @@ _resolve_chat_session() {
 			remote_ref="${remote_ref:-main}"
 		fi
 		jq -n --arg session_id "$session_id" --arg name "$name" --arg remote_ref "$remote_ref" \
-			'{session_id: $session_id, name: $name, remote_ref: $remote_ref}' >"$state_file"
+			'{session_id: $session_id, name: $name, remote_ref: $remote_ref}' >"$state_json"
 		_session_args_ref=(--session-id "$session_id" --worktree "$name")
 	fi
 }

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -229,6 +229,17 @@ _gh_issue_edit() {
 	local agent_model
 	agent_model=$(gh config get ai.issue.model 2>/dev/null || true)
 
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "issue_body.md" "$gh_issue_body"
+	_save_context_file "$context_dir" "issue_comments.md" "$gh_issue_comments"
+	local render_env=()
+	if [[ -n "$gh_issue_context" ]]; then
+		_save_context_file "$context_dir" "issue_context.md" "$gh_issue_context"
+		render_env+=(GH_ISSUE_CONTEXT_FILE="$context_dir/issue_context.md")
+	fi
+
 	local output
 	# Generate updated issue content using assistant
 	output=$(
@@ -236,14 +247,17 @@ _gh_issue_edit() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
 				GH_ISSUE_NUMBER="$gh_issue_number" \
 					GH_ISSUE_TITLE="$gh_issue_title" \
-					GH_ISSUE_BODY="$gh_issue_body" \
+					GH_ISSUE_BODY_FILE="$context_dir/issue_body.md" \
 					GH_ISSUE_LABELS="$gh_issue_labels" \
-					GH_ISSUE_COMMENTS="$gh_issue_comments" \
+					GH_ISSUE_COMMENTS_FILE="$context_dir/issue_comments.md" \
 					GH_ISSUE_DESCRIPTION="$gh_issue_description" \
-					GH_ISSUE_CONTEXT="$gh_issue_context" \
+					"${render_env[@]}" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got issue content
 	if [[ -z "$output" ]]; then
@@ -399,6 +413,12 @@ _gh_issue_plan() {
 		gh_issue_focus="<focus>${gh_issue_description}</focus>"
 	fi
 
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "issue_body.md" "$gh_issue_body"
+	_save_context_file "$context_dir" "issue_comments.md" "$gh_issue_comments"
+
 	local output
 	# Generate implementation plan using assistant
 	output=$(
@@ -406,13 +426,16 @@ _gh_issue_plan() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
 				GH_ISSUE_NUMBER="$gh_issue_number" \
 					GH_ISSUE_TITLE="$gh_issue_title" \
-					GH_ISSUE_BODY="$gh_issue_body" \
+					GH_ISSUE_BODY_FILE="$context_dir/issue_body.md" \
 					GH_ISSUE_LABELS="$gh_issue_labels" \
-					GH_ISSUE_COMMENTS="$gh_issue_comments" \
+					GH_ISSUE_COMMENTS_FILE="$context_dir/issue_comments.md" \
 					GH_ISSUE_FOCUS="$gh_issue_focus" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got content
 	if [[ -z "$output" ]]; then
@@ -574,15 +597,27 @@ _gh_issue_chat() {
 		gh_issue_focus="<focus>${gh_issue_description}</focus>"
 	fi
 
+	# Resolve session directory and create context files
+	local session_id name session_dir
+	session_id=$(_uuidv5 "$gh_issue_url")
+	name=$(printf '%s' "$gh_issue_url" | awk -F/ '{sub(/s$/, "", $(NF-1)); print $(NF-1) "-" $NF}')
+	local git_root
+	_git_repo_path git_root || return 1
+	session_dir="$git_root/.claude/sessions/$session_id"
+	mkdir -p "$session_dir"
+
+	# Save large context to files
+	_save_context_file "$session_dir" "issue_body.md" "$gh_issue_body"
+	_save_context_file "$session_dir" "issue_comments.md" "$gh_issue_comments"
+
 	# Render context and pipe to agent
 	local preamble
 	preamble=$(
 		GH_ISSUE_NUMBER="$gh_issue_number" \
 			GH_ISSUE_TITLE="$gh_issue_title" \
-			GH_ISSUE_BODY="$gh_issue_body" \
 			GH_ISSUE_LABELS="$gh_issue_labels" \
-			GH_ISSUE_COMMENTS="$gh_issue_comments" \
 			GH_ISSUE_FOCUS="$gh_issue_focus" \
+			GH_SESSION_DIR="$session_dir" \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 	)
 
@@ -661,6 +696,15 @@ _gh_issue_create() {
 	local agent_model
 	agent_model=$(gh config get ai.issue.model 2>/dev/null || true)
 
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	local render_env=()
+	if [[ -n "$gh_issue_context" ]]; then
+		_save_context_file "$context_dir" "issue_context.md" "$gh_issue_context"
+		render_env+=(GH_ISSUE_CONTEXT_FILE="$context_dir/issue_context.md")
+	fi
+
 	local output
 	# Generate issue content using assistant run
 	output=$(
@@ -668,10 +712,13 @@ _gh_issue_create() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
 				GH_ISSUE_DESCRIPTION="$gh_issue_description" \
 					GH_ISSUE_LABELS="" \
-					GH_ISSUE_CONTEXT="$gh_issue_context" \
+					"${render_env[@]}" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got issue content
 	if [[ -z "$output" ]]; then

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -147,19 +147,30 @@ _gh_pr_create() {
 		gh_pr_description_context="<description>${gh_pr_description}</description>"
 	fi
 
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "pr_diff.patch" "$gh_pr_diff"
+	_save_context_file "$context_dir" "pr_diff_stat.txt" "$gh_pr_diff_stat"
+	_save_context_file "$context_dir" "pr_log.txt" "$gh_pr_log"
+	_save_context_file "$context_dir" "pr_commits.txt" "$gh_pr_commits"
+
 	local output
 	# Generate PR content using assistant run
 	output=$(
 		gum spin --title "Generating GitHub pull request..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
-				GH_PR_DIFF="$gh_pr_diff" \
-					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
-					GH_PR_LOG="$gh_pr_log" \
-					GH_PR_COMMITS="$gh_pr_commits" \
+				GH_PR_DIFF_FILE="$context_dir/pr_diff.patch" \
+					GH_PR_DIFF_STAT_FILE="$context_dir/pr_diff_stat.txt" \
+					GH_PR_LOG_FILE="$context_dir/pr_log.txt" \
+					GH_PR_COMMITS_FILE="$context_dir/pr_commits.txt" \
 					GH_PR_DESCRIPTION="$gh_pr_description_context" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got PR content
 	if [[ -z "$output" ]]; then
@@ -342,6 +353,14 @@ _gh_pr_edit() {
 	local agent_model
 	agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
 
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "pr_diff.patch" "$gh_pr_diff"
+	_save_context_file "$context_dir" "pr_diff_stat.txt" "$gh_pr_diff_stat"
+	_save_context_file "$context_dir" "pr_commits.txt" "$gh_pr_commits"
+	_save_context_file "$context_dir" "pr_body.md" "$gh_pr_body"
+
 	local output
 	# Generate updated PR content using assistant
 	output=$(
@@ -349,14 +368,17 @@ _gh_pr_edit() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
 				GH_PR_NUMBER="$gh_pr_number" \
 					GH_PR_TITLE="$gh_pr_title" \
-					GH_PR_BODY="$gh_pr_body" \
-					GH_PR_DIFF="$gh_pr_diff" \
-					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
-					GH_PR_COMMITS="$gh_pr_commits" \
+					GH_PR_DIFF_FILE="$context_dir/pr_diff.patch" \
+					GH_PR_DIFF_STAT_FILE="$context_dir/pr_diff_stat.txt" \
+					GH_PR_COMMITS_FILE="$context_dir/pr_commits.txt" \
+					GH_PR_BODY_FILE="$context_dir/pr_body.md" \
 					GH_PR_DESCRIPTION="$gh_pr_description" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got PR content
 	if [[ -z "$output" ]]; then
@@ -582,20 +604,30 @@ _gh_pr_review() {
 		gh_pr_description_context="<description>$gh_pr_description</description>"
 	fi
 
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "pr_diff.patch" "$gh_pr_diff"
+	_save_context_file "$context_dir" "pr_diff_stat.txt" "$gh_pr_diff_stat"
+	_save_context_file "$context_dir" "pr_commits.txt" "$gh_pr_commits"
+
 	local gh_pr_body
 	# Generate review content using assistant run
 	gh_pr_body=$(
 		gum spin --title "Generating GitHub pull request #$gh_pr_number review..." -- \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
 				GH_PR_NUMBER="$gh_pr_number" \
-					GH_PR_DIFF="$gh_pr_diff" \
-					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
-					GH_PR_COMMITS="$gh_pr_commits" \
+					GH_PR_DIFF_FILE="$context_dir/pr_diff.patch" \
+					GH_PR_DIFF_STAT_FILE="$context_dir/pr_diff_stat.txt" \
+					GH_PR_COMMITS_FILE="$context_dir/pr_commits.txt" \
 					GH_PR_HEAD="$gh_pr_head" \
 					GH_PR_DESCRIPTION="$gh_pr_description_context" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got review content
 	if [[ -z "$gh_pr_body" ]]; then
@@ -690,6 +722,13 @@ _gh_pr_explain() {
 	local agent_model
 	agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
 
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "pr_diff.patch" "$gh_pr_diff"
+	_save_context_file "$context_dir" "pr_diff_stat.txt" "$gh_pr_diff_stat"
+	_save_context_file "$context_dir" "pr_commits.txt" "$gh_pr_commits"
+
 	local output
 	# Generate explanation using assistant run
 	output=$(
@@ -698,13 +737,16 @@ _gh_pr_explain() {
 				GH_PR_NUMBER="$gh_pr_number" \
 					GH_PR_TITLE="$gh_pr_title" \
 					GH_PR_BODY="$gh_pr_body" \
-					GH_PR_DIFF="$gh_pr_diff" \
-					GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
-					GH_PR_COMMITS="$gh_pr_commits" \
+					GH_PR_DIFF_FILE="$context_dir/pr_diff.patch" \
+					GH_PR_DIFF_STAT_FILE="$context_dir/pr_diff_stat.txt" \
+					GH_PR_COMMITS_FILE="$context_dir/pr_commits.txt" \
 					GH_PR_HEAD="$gh_pr_head" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got explanation content
 	if [[ -z "$output" ]]; then
@@ -902,17 +944,29 @@ _gh_pr_chat() {
 	local gh_current_branch
 	gh_current_branch=$(git branch --show-current 2>/dev/null || echo "")
 
+	# Resolve session directory and create context files
+	local session_id name session_dir
+	session_id=$(_uuidv5 "$gh_pr_url")
+	name=$(printf '%s' "$gh_pr_url" | awk -F/ '{sub(/s$/, "", $(NF-1)); print $(NF-1) "-" $NF}')
+	local git_root
+	_git_repo_path git_root || return 1
+	session_dir="$git_root/.claude/sessions/$session_id"
+	mkdir -p "$session_dir"
+
+	# Save large context to files
+	_save_context_file "$session_dir" "pr_diff.patch" "$gh_pr_diff"
+	_save_context_file "$session_dir" "pr_diff_stat.txt" "$gh_pr_diff_stat"
+	_save_context_file "$session_dir" "pr_commits.txt" "$gh_pr_commits"
+
 	local preamble
 	preamble=$(
 		GH_PR_NUMBER="$gh_pr_number" \
 			GH_PR_TITLE="$gh_pr_title" \
 			GH_PR_BODY="$gh_pr_body" \
-			GH_PR_DIFF="$gh_pr_diff" \
-			GH_PR_DIFF_STAT="$gh_pr_diff_stat" \
-			GH_PR_COMMITS="$gh_pr_commits" \
 			GH_PR_HEAD="$gh_pr_head" \
 			GH_PR_FOCUS="$gh_pr_focus" \
 			GH_CURRENT_BRANCH="$gh_current_branch" \
+			GH_SESSION_DIR="$session_dir" \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 	)
 

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -138,17 +138,14 @@ _gh_run_explain() {
 			gh run view "$gh_run_id" --log || true)
 	fi
 
-	# Truncate log to avoid OS ARG_MAX limits when passing via environment variable.
-	# GitHub Actions logs can be many MBs; AI context windows are finite anyway.
-	local _max_log_bytes=100000
-	if [[ ${#gh_run_log} -gt $_max_log_bytes ]]; then
-		local _tail
-		_tail=$(printf '%s' "$gh_run_log" | tail -c "$_max_log_bytes")
-		gh_run_log="[... log truncated, showing last ${_max_log_bytes} bytes ...]"$'\n'"$_tail"
-	fi
-
 	local agent_model
 	agent_model=$(gh config get ai.run.model 2>/dev/null || true)
+
+	# Create context directory and save large content to files (no truncation needed)
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "run_jobs.txt" "$gh_run_jobs"
+	_save_context_file "$context_dir" "run_log.txt" "$gh_run_log"
 
 	local output
 	# Generate explanation using assistant run
@@ -160,11 +157,14 @@ _gh_run_explain() {
 					GH_RUN_URL="$gh_run_url" \
 					GH_RUN_EVENT="$gh_run_event" \
 					GH_RUN_BRANCH="$gh_run_branch" \
-					GH_RUN_JOBS="$gh_run_jobs" \
-					GH_RUN_LOG="$gh_run_log" \
+					GH_RUN_JOBS_FILE="$context_dir/run_jobs.txt" \
+					GH_RUN_LOG_FILE="$context_dir/run_log.txt" \
 					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 			)
 	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
 
 	# Validate we got explanation content
 	if [[ -z "$output" ]]; then
@@ -331,14 +331,6 @@ _gh_run_chat() {
 			gh run view "$gh_run_id" --log || true)
 	fi
 
-	# Truncate log to avoid OS ARG_MAX limits when passing via environment variable.
-	local _max_log_bytes=100000
-	if [[ ${#gh_run_log} -gt $_max_log_bytes ]]; then
-		local _tail
-		_tail=$(printf '%s' "$gh_run_log" | tail -c "$_max_log_bytes")
-		gh_run_log="[... log truncated, showing last ${_max_log_bytes} bytes ...]"$'\n'"$_tail"
-	fi
-
 	local gh_run_focus=""
 	if [[ -n "$gh_run_description" ]]; then
 		gh_run_focus="<focus>${gh_run_description}</focus>"
@@ -347,6 +339,19 @@ _gh_run_chat() {
 	# Capture current branch for template context
 	local gh_current_branch
 	gh_current_branch=$(git branch --show-current 2>/dev/null || echo "")
+
+	# Resolve session directory and create context files
+	local session_id name session_dir
+	session_id=$(_uuidv5 "$gh_run_url")
+	name=$(printf '%s' "$gh_run_url" | awk -F/ '{sub(/s$/, "", $(NF-1)); print $(NF-1) "-" $NF}')
+	local git_root
+	_git_repo_path git_root || return 1
+	session_dir="$git_root/.claude/sessions/$session_id"
+	mkdir -p "$session_dir"
+
+	# Save large context to files (no truncation needed with file-backed approach)
+	_save_context_file "$session_dir" "run_jobs.txt" "$gh_run_jobs"
+	_save_context_file "$session_dir" "run_log.txt" "$gh_run_log"
 
 	# Render context and pipe to agent
 	local preamble
@@ -358,9 +363,8 @@ _gh_run_chat() {
 			GH_RUN_URL="$gh_run_url" \
 			GH_RUN_EVENT="$gh_run_event" \
 			GH_RUN_BRANCH="$gh_run_branch" \
-			GH_RUN_JOBS="$gh_run_jobs" \
-			GH_RUN_LOG="$gh_run_log" \
 			GH_CURRENT_BRANCH="$gh_current_branch" \
+			GH_SESSION_DIR="$session_dir" \
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
 	)
 

--- a/scripts/gh_worktree.sh
+++ b/scripts/gh_worktree.sh
@@ -32,9 +32,15 @@ _gh_worktree_create() {
 	eval "$(printf '%s' "$input" | jq -r "$gh_worktree_jq")"
 
 	# Second pass: overlay remote_ref from the session state file (same jq filter)
-	local session_state_file="${gh_worktree_cwd}/.claude/sessions/${gh_worktree_session_id}.json"
+	# Try new directory format first, then fall back to old .json format
+	local session_state_file="${gh_worktree_cwd}/.claude/sessions/${gh_worktree_session_id}/state.json"
 	if [[ -f "$session_state_file" ]]; then
 		eval "$(jq -r "$gh_worktree_jq" "$session_state_file")"
+	else
+		session_state_file="${gh_worktree_cwd}/.claude/sessions/${gh_worktree_session_id}.json"
+		if [[ -f "$session_state_file" ]]; then
+			eval "$(jq -r "$gh_worktree_jq" "$session_state_file")"
+		fi
 	fi
 
 	local gh_worktree_path

--- a/templates/gh_issue_chat.tmpl
+++ b/templates/gh_issue_chat.tmpl
@@ -3,13 +3,15 @@ You are helping with a GitHub issue. Here is the context:
 <issue>
 Number: ${GH_ISSUE_NUMBER}
 Title: ${GH_ISSUE_TITLE}
-Body: ${GH_ISSUE_BODY}
 Labels: ${GH_ISSUE_LABELS}
 </issue>
 
-<comments>
-${GH_ISSUE_COMMENTS}
-</comments>
+<context-files>
+The following files contain detailed context for this issue.
+Read them to understand the full context:
+- ${GH_SESSION_DIR}/issue_body.md — issue body
+- ${GH_SESSION_DIR}/issue_comments.md — all comments
+</context-files>
 
 ${GH_ISSUE_FOCUS}
 
@@ -25,4 +27,6 @@ Your first message contains the full context for GitHub issue
 #${GH_ISSUE_NUMBER}. Summarize the issue in your reply — do not use
 tools, read files, or explore the codebase. Then ask if the user
 wants to discuss it, plan an implementation, or start working.
+
+Read the issue body and comments files to understand the full context.
 </instructions>

--- a/templates/gh_pr_chat.tmpl
+++ b/templates/gh_pr_chat.tmpl
@@ -11,17 +11,13 @@ Branch: ${GH_CURRENT_BRANCH}
 ${GH_PR_BODY}
 </description>
 
-<diffstat>
-${GH_PR_DIFF_STAT}
-</diffstat>
-
-<diff>
-${GH_PR_DIFF}
-</diff>
-
-<commits>
-${GH_PR_COMMITS}
-</commits>
+<context-files>
+The following files contain detailed context for this pull request.
+Read them to understand the changes:
+- ${GH_SESSION_DIR}/pr_diff_stat.txt — diffstat (file change summary)
+- ${GH_SESSION_DIR}/pr_diff.patch — full unified diff
+- ${GH_SESSION_DIR}/pr_commits.txt — commit messages
+</context-files>
 
 ${GH_PR_FOCUS}
 
@@ -41,4 +37,7 @@ Your first message contains the full context for GitHub pull request
 tools, read files, or re-analyze the diff. Then ask how the user
 would like to proceed — review specific areas, discuss trade-offs,
 or ask questions.
+
+Read the diffstat file first for an overview, then read specific parts
+of the diff as needed.
 </instructions>

--- a/templates/gh_run_chat.tmpl
+++ b/templates/gh_run_chat.tmpl
@@ -10,13 +10,12 @@ Current Branch: ${GH_CURRENT_BRANCH}
 URL: ${GH_RUN_URL}
 </run>
 
-<jobs>
-${GH_RUN_JOBS}
-</jobs>
-
-<log>
-${GH_RUN_LOG}
-</log>
+<context-files>
+The following files contain detailed context for this workflow run.
+Read them to understand the failure:
+- ${GH_SESSION_DIR}/run_jobs.txt — job details
+- ${GH_SESSION_DIR}/run_log.txt — full workflow log
+</context-files>
 
 ${GH_RUN_FOCUS}
 
@@ -36,4 +35,7 @@ Your first message contains the full context for GitHub Actions run
 re-fetch logs, or generate a new analysis. Then ask how the user
 would like to proceed — investigate specific failures, discuss
 fixes, or start implementing.
+
+Read the job details file first for an overview, then read relevant
+parts of the full log as needed.
 </instructions>

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -275,6 +275,74 @@ setup() {
 	[[ "$output" == *"line three"* ]]
 }
 
+# File-backed _cmd_render tests
+# These test the *_FILE env var support for bypassing ARG_MAX
+
+@test "_cmd_render: reads file content from VAR_FILE env var" {
+	local tmpdir="$BATS_TMPDIR/render-file-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Diff:\n${GH_PR_DIFF}\nEnd.\n' >"$tmpdir/test.tmpl"
+	printf 'line one\nline two\nline three' >"$tmpdir/diff.patch"
+
+	local output
+	output=$(GH_PR_DIFF_FILE="$tmpdir/diff.patch" _cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *"line one"* ]]
+	[[ "$output" == *"line two"* ]]
+	[[ "$output" == *"line three"* ]]
+}
+
+@test "_cmd_render: direct env var takes priority over _FILE" {
+	local tmpdir="$BATS_TMPDIR/render-priority-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Value: ${MY_VAR}\n' >"$tmpdir/test.tmpl"
+	printf 'from file' >"$tmpdir/value.txt"
+
+	local output
+	output=$(MY_VAR="from env" MY_VAR_FILE="$tmpdir/value.txt" _cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *"Value: from env"* ]]
+	[[ "$output" != *"from file"* ]]
+}
+
+@test "_cmd_render: nonexistent _FILE path produces empty string" {
+	local tmpdir="$BATS_TMPDIR/render-missing-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Value: [${MY_VAR}]\n' >"$tmpdir/test.tmpl"
+
+	local output
+	output=$(MY_VAR_FILE="/nonexistent/file.txt" _cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *"Value: []"* ]]
+}
+
+@test "_cmd_render: multiline file content preserved in _FILE" {
+	local tmpdir="$BATS_TMPDIR/render-multiline-file-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Content:\n${MY_CONTENT}\nEnd.\n' >"$tmpdir/test.tmpl"
+	printf 'line one\nline two\nline three' >"$tmpdir/content.txt"
+
+	local output
+	output=$(MY_CONTENT_FILE="$tmpdir/content.txt" _cmd_render "$tmpdir/test.tmpl")
+
+	[[ "$output" == *"line one"* ]]
+	[[ "$output" == *"line two"* ]]
+	[[ "$output" == *"line three"* ]]
+}
+
+@test "_cmd_render: patterns in file content not re-expanded" {
+	local tmpdir="$BATS_TMPDIR/render-safety-file-test-$$"
+	mkdir -p "$tmpdir"
+	printf 'Diff:\n${GH_DIFF}\nEnd.\n' >"$tmpdir/test.tmpl"
+	printf 'contains ${SECRET_TOKEN} and ${OTHER} patterns' >"$tmpdir/diff.patch"
+
+	local output
+	output=$(GH_DIFF_FILE="$tmpdir/diff.patch" _cmd_render "$tmpdir/test.tmpl")
+
+	# Patterns from file should be preserved as-is, not re-expanded
+	[[ "$output" == *'contains ${SECRET_TOKEN} and ${OTHER} patterns'* ]]
+}
+
 # ---------------------------------------------------------------------------
 # _parse_title
 # ---------------------------------------------------------------------------

--- a/tests/gh_session.bats
+++ b/tests/gh_session.bats
@@ -109,7 +109,7 @@ setup() {
 	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
 
 	local session_id="${args[1]}"
-	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${session_id}.json"
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${session_id}/state.json"
 	[[ -f "$state_file" ]]
 }
 
@@ -183,16 +183,16 @@ setup() {
 	_resolve_chat_session args_run "https://github.com/owner/repo/actions/runs/123456" "" ""
 
 	local sessions_dir="$BATS_TEST_TMPDIR/.claude/sessions"
-	[[ -f "$sessions_dir/${args_issue[1]}.json" ]]
-	[[ -f "$sessions_dir/${args_pr[1]}.json" ]]
-	[[ -f "$sessions_dir/${args_run[1]}.json" ]]
+	[[ -f "$sessions_dir/${args_issue[1]}/state.json" ]]
+	[[ -f "$sessions_dir/${args_pr[1]}/state.json" ]]
+	[[ -f "$sessions_dir/${args_run[1]}/state.json" ]]
 }
 
 @test "_resolve_chat_session: state file contains valid session_id and name" {
 	local args=()
 	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
 
-	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}/state.json"
 	local content
 	content=$(cat "$state_file")
 
@@ -220,7 +220,7 @@ setup() {
 	local args=()
 	_resolve_chat_session args "https://github.com/owner/repo/pull/7" "" "feat-my-branch"
 
-	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}/state.json"
 	local content
 	content=$(cat "$state_file")
 
@@ -239,7 +239,7 @@ setup() {
 	local args=()
 	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
 
-	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}/state.json"
 	local content
 	content=$(cat "$state_file")
 
@@ -258,7 +258,7 @@ setup() {
 	local args=()
 	_resolve_chat_session args "https://github.com/owner/repo/issues/42" "" ""
 
-	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}.json"
+	local state_file="$BATS_TEST_TMPDIR/.claude/sessions/${args[1]}/state.json"
 	local content
 	content=$(cat "$state_file")
 


### PR DESCRIPTION
## Summary

Large context (diffs, logs, issue bodies) is now written to temporary files and read by the template renderer via
`_FILE`-suffixed environment variables, instead of being passed inline through environment variables. This eliminates
`E2BIG` / `Argument list too long` failures that occurred when PR diffs or workflow logs exceeded the OS `ARG_MAX` limit
(typically ~256 KB on macOS). Chat-mode commands store context files inside the session directory so they persist across
resume cycles.

## Risk Level

**Medium** — touches the core template renderer and every command that passes large context (issue edit/plan/chat,
PR create/edit/review/explain/chat, run explain/chat). The awk `readfile()` fallback is straightforward, but the
migration from inline env vars to file-backed vars spans many code paths.

## Changes

### Behavior & Execution Flow

- `_cmd_render` (`gh_cmd.sh:14-50`) gains a `readfile()` awk function. During substitution, if `ENVIRON[VAR]` is empty
  but `ENVIRON[VAR_FILE]` is set, the renderer reads the file at that path. The single-pass guarantee is preserved —
  content from files is never re-scanned for `${...}` patterns.
- Two new helpers: `_create_context_dir` creates a per-invocation temp directory, and `_save_context_file` writes content
  into it using the `printf` builtin (no `execve`, so no ARG_MAX impact).
- **Ask-mode commands** (issue edit/plan/create, PR create/edit/review/explain, run explain) create an ephemeral context
  directory, save large content to files, pass `*_FILE` env vars to the renderer, then `rm -rf` the directory after the
  AI call completes.
- **Chat-mode commands** (issue chat, PR chat, run chat) save context files into the session directory
  (`$git_root/.claude/sessions/$session_id/`) so they survive across session resumes. Templates reference
  `${GH_SESSION_DIR}` to point the agent at the files.
- Session storage migrates from a flat `$session_id.json` file to a `$session_id/` directory containing `state.json`
  plus context files. Both `_resolve_chat_session` and `_try_resume_chat_session` check the new directory format first,
  then fall back to the old `.json` format for backward compatibility.
- The run explain/chat log truncation workaround (`_max_log_bytes=100000`) is removed — file-backed rendering handles
  arbitrarily large logs without hitting ARG_MAX.

### Design Decisions

- **`_FILE` suffix convention** mirrors patterns from Docker secrets and 12-factor tooling — callers opt in per-variable,
  and the direct env var always wins over the file variant, preventing surprises.
- **Session directory as context store** for chat commands avoids a separate temp directory lifecycle — context files live
  alongside `state.json` and are cleaned up by the existing `--new-session` logic (`rm -rf` on the directory).
- **No truncation** for workflow logs: the old 100 KB cap was a workaround for ARG_MAX; with file-backed rendering the
  full log reaches the AI model, improving diagnostic accuracy.
- Chat-mode templates (`gh_issue_chat.tmpl`, `gh_pr_chat.tmpl`, `gh_run_chat.tmpl`) now list context files explicitly
  and instruct the agent to read them, rather than inlining potentially huge content into the prompt preamble.

### Edge Cases

- **Nonexistent `_FILE` path**: `readfile()` returns an empty string (awk `getline` fails silently), matching the
  behavior of an unset env var. Tested in `gh_cmd.bats`.
- **Backward compatibility**: `_try_resume_chat_session` and `_resolve_chat_session` accept both `$id/state.json`
  (new) and `$id.json` (old). `--new-session` cleans up both formats. `gh_worktree.sh` tries the new path first,
  then falls back.
- **Patterns in file content**: `${...}` tokens inside file content (e.g., shell variables in a diff) are never
  re-expanded — the awk substitution concatenates the file content as a literal string, then advances past it.
- **Direct env var priority**: when both `MY_VAR` and `MY_VAR_FILE` are set, the direct value wins. This preserves
  backward compatibility for any callers that still pass content inline.

## Testing

Run the full test suite:

```sh
npx bats tests/
```

New tests in `tests/gh_cmd.bats`:
- `_cmd_render: reads file content from VAR_FILE env var` — basic file-backed substitution
- `_cmd_render: direct env var takes priority over _FILE` — precedence rule
- `_cmd_render: nonexistent _FILE path produces empty string` — graceful degradation
- `_cmd_render: multiline file content preserved in _FILE` — newlines survive round-trip
- `_cmd_render: patterns in file content not re-expanded` — security / correctness invariant

Updated tests in `tests/gh_session.bats` validate the new `$id/state.json` directory layout.

## Impact

- **Breaking Changes:** Session state moves from `$id.json` to `$id/state.json`. Existing sessions are detected and
  resumed via the fallback path, but new sessions always use the directory format. `gh-worktree` consumers are updated
  in this PR.
- **Performance:** Improved — eliminates `execve` overhead for large payloads and removes the 100 KB log truncation cap.
- **Security:** File-backed content is written to `$TMPDIR` (ask mode) or the repo-local `.claude/sessions/` directory
  (chat mode), both with default user-only permissions. No new trust boundaries introduced.

<!-- markdownlint-disable-file MD013 MD022 MD041 MD047 -->