### PR TITLE
Add alt-C chat keybindings to gh-fzf integration for issues, PRs, and runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,13 @@ source "$HOME/.local/share/gh/extensions/gh-ai/extras/gh_fzf.sh"
 | Context        | Key     | Action                                           |
 | -------------- | ------- | ------------------------------------------------ |
 | `gh-fzf issue` | `alt-P` | Generate AI plan for the selected issue          |
+| `gh-fzf issue` | `alt-C` | Chat about the selected issue with AI            |
 | `gh-fzf pr`    | `alt-E` | Explain the selected PR                          |
 | `gh-fzf pr`    | `alt-A` | Approve the selected PR via AI review            |
 | `gh-fzf pr`    | `alt-N` | Request changes on the selected PR via AI review |
+| `gh-fzf pr`    | `alt-C` | Chat about the selected PR with AI               |
 | `gh-fzf run`   | `alt-E` | Explain the selected workflow run failure        |
+| `gh-fzf run`   | `alt-C` | Chat about the selected workflow run with AI     |
 
 ## See Also
 

--- a/extras/gh_fzf.sh
+++ b/extras/gh_fzf.sh
@@ -8,18 +8,22 @@
 #
 #   gh-fzf issue
 #     alt-P   Generate and view AI plan for the selected issue
+#     alt-C   Chat about the selected issue with AI
 #
 #   gh-fzf pr
 #     alt-E   Explain the selected PR with AI
 #     alt-A   Approve the selected PR via AI review
 #     alt-N   Request changes on the selected PR via AI review
+#     alt-C   Chat about the selected PR with AI
 #
 #   gh-fzf run
 #     alt-E   Explain the selected workflow run failure with AI
+#     alt-C   Chat about the selected workflow run with AI
 #
 
 _gh_fzf_issue_opts=(
 	'--bind "alt-P:execute(gh ai issue plan {1} | gum format | gum pager)"'
+	'--bind "alt-C:execute(gh ai issue chat {1})"'
 )
 export GH_FZF_ISSUE_OPTS="${GH_FZF_ISSUE_OPTS:+${GH_FZF_ISSUE_OPTS} }${_gh_fzf_issue_opts[*]}"
 unset _gh_fzf_issue_opts
@@ -28,12 +32,14 @@ _gh_fzf_pr_opts=(
 	'--bind "alt-E:execute(gh ai pr explain {1} | gum pager)"'
 	'--bind "alt-A:execute(gh ai pr review {1} -- --approve)"'
 	'--bind "alt-N:execute(gh ai pr review {1} -- --request-changes)"'
+	'--bind "alt-C:execute(gh ai pr chat {1})"'
 )
 export GH_FZF_PR_OPTS="${GH_FZF_PR_OPTS:+${GH_FZF_PR_OPTS} }${_gh_fzf_pr_opts[*]}"
 unset _gh_fzf_pr_opts
 
 _gh_fzf_run_opts=(
 	'--bind "alt-E:execute(gh ai run explain {-1} | gum format | gum pager)"'
+	'--bind "alt-C:execute(gh ai run chat {-1})"'
 )
 export GH_FZF_RUN_OPTS="${GH_FZF_RUN_OPTS:+${GH_FZF_RUN_OPTS} }${_gh_fzf_run_opts[*]}"
 unset _gh_fzf_run_opts


### PR DESCRIPTION
## Summary

Adds `alt-C` keybindings across all three gh-fzf contexts (issue, pr, run) to launch interactive AI chat sessions directly from the fzf picker. This complements the existing read-only AI actions (plan, explain, review) with a conversational interface. Both the shell integration script (`extras/gh_fzf.sh`) and the README documentation are updated.

## Risk Level

**Low** — Documentation and additive keybinding changes only; no existing behavior is modified.

## Changes

### Behavior & Execution Flow

After sourcing the updated `extras/gh_fzf.sh`, pressing `alt-C` in any gh-fzf context executes the corresponding `gh ai <context> chat` command with the selected item's identifier. Unlike the existing explain/plan bindings, the chat commands do not pipe through `gum format` or `gum pager`, since they launch an interactive session that handles its own I/O.

### Design Decisions

- **No pager wrapping for chat:** The `gh ai ... chat` commands are interactive by nature, so they are invoked directly via `execute(...)` without piping to `gum pager` or `gum format`. This contrasts with the read-only commands (`alt-E`, `alt-P`) that do use pagers, and is consistent with the expectation that chat manages its own terminal output.
- **Consistent `alt-C` mnemonic:** The same key (`alt-C` for "Chat") is reused across all three contexts for discoverability and muscle memory.

### Edge Cases

- If `GH_FZF_ISSUE_OPTS`, `GH_FZF_PR_OPTS`, or `GH_FZF_RUN_OPTS` already contain an `alt-C` binding from user configuration, fzf will use the last binding defined. The user-defined value is prepended (via the existing `${VAR:+${VAR} }` pattern), so the extension's binding will take precedence.
- `gh-fzf run` uses `{-1}` (last field) for the run identifier, consistent with the existing `alt-E` binding in `gh_fzf.sh:38`.

## Testing

1. Source the updated script: `source extras/gh_fzf.sh`
2. Run `gh fzf issue`, select an issue, and press `alt-C` — verify an interactive AI chat session starts for that issue.
3. Repeat with `gh fzf pr` and `gh fzf run`.
4. Confirm existing keybindings (`alt-P`, `alt-E`, `alt-A`, `alt-N`) still work as expected.

## Impact

- **Breaking Changes:** No
- **Performance:** No change
- **Security:** Chat sessions use the same `gh ai` authentication and trust boundaries as existing AI commands; no new credentials or data flows are introduced.

<!-- markdownlint-disable-file MD013 MD022 MD041 MD047 -->