### PR TITLE
Add `gh ai pr comment` subcommand

### DIFF
--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -640,6 +640,204 @@ _gh_pr_review() {
 	gh pr review "$gh_pr_number" --body "$gh_pr_body" "${passthrough[@]}"
 }
 
+# Parse PR comment arguments (before -- separator)
+#
+# Extracts the PR number (first numeric arg, with auto-detect fallback)
+# and -d/--description value. Unknown flags produce an error with a hint
+# to use --.
+#
+# Example: _parse_pr_comment_args num desc 42 -d "summarise open threads"
+_parse_pr_comment_args() {
+	local -n gh_pr_number_ref="$1"
+	# shellcheck disable=SC2178 # bash nameref: looks like scalar redefining array, but it's a reference
+	local -n gh_pr_description_ref="$2"
+	shift 2
+
+	local raw_args=("$@")
+	local skip_next=false
+	local i=0
+
+	while [[ $i -lt ${#raw_args[@]} ]]; do
+		if [ "$skip_next" = true ]; then
+			skip_next=false
+			((++i))
+			continue
+		fi
+
+		case "${raw_args[$i]}" in
+		--description | -d)
+			if ((i + 1 >= ${#raw_args[@]})); then
+				gum log --level error "${raw_args[$i]} requires a value"
+				return 1
+			fi
+			gh_pr_description_ref="${raw_args[$((i + 1))]}"
+			skip_next=true
+			;;
+		--description=*)
+			# shellcheck disable=SC2034 # nameref: set by caller
+			gh_pr_description_ref="${raw_args[$i]#--description=}"
+			;;
+		-*)
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh pr comment)"
+			return 1
+			;;
+		*)
+			local arg="${raw_args[$i]#\#}"
+			if [[ -z "$gh_pr_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
+				gh_pr_number_ref="$arg"
+			else
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
+				return 1
+			fi
+			;;
+		esac
+		((++i))
+	done
+
+	# Auto-detect PR number from current branch if not found in args
+	if [[ -z "$gh_pr_number_ref" ]]; then
+		gh_pr_number_ref=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+	fi
+}
+
+# PR comment help function
+#
+# Displays help information for the PR comment command
+# including usage examples and available options.
+_show_pr_comment_help() {
+	cat <<'EOF'
+gh ai pr comment - Post an AI-generated comment on a pull request
+
+USAGE:
+    gh ai pr comment [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_COMMENT_OPTIONS]
+
+DESCRIPTION:
+    Posts a GitHub PR comment with AI-generated content based on the PR body,
+    existing comments, and the description you provide. Auto-detects PR from
+    the current branch if no number is provided. Options after -- are passed
+    directly to gh pr comment.
+
+FLAGS:
+    -d, --description string   Context or instructions for the AI comment (required)
+
+EXAMPLES:
+    gh ai pr comment 42 -d "summarise the open review threads"
+    gh ai pr comment -d "ask about the migration strategy"
+    echo "some notes" | gh ai pr comment 42 -d "incorporate this context"
+    gh ai pr comment 42 -d "request changes" -- --edit-last
+EOF
+}
+
+# PR Comment implementation
+#
+# Posts a GitHub PR comment with AI-generated content.
+# Renders a prompt template with the PR body, existing comments, and
+# description context, sends it to the AI provider, and posts the response
+# as a comment. Auto-detects PR number from current branch if not provided.
+#
+# Usage: _gh_pr_comment [NUMBER] -d <DESCRIPTION> [-- OPTIONS]
+_gh_pr_comment() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_pr_comment_help
+		return 0
+		;;
+	esac
+
+	local ai_args=()
+	local passthrough=()
+	_split_on_separator ai_args passthrough "$@"
+
+	local template_file
+	# shellcheck disable=SC2154
+	template_file="$_gh_ai_source_dir/templates/gh_pr_comment.tmpl"
+
+	local gh_pr_number=""
+	local gh_pr_description=""
+	_parse_pr_comment_args gh_pr_number gh_pr_description "${ai_args[@]}"
+
+	if [[ -z "$gh_pr_number" ]]; then
+		gum log --level error "No PR number provided and could not detect PR for current branch"
+		gum log --level info "Usage: gh ai pr comment [PR_NUMBER] -d <DESCRIPTION> [-- OPTIONS]"
+		return 1
+	fi
+
+	if [[ -z "$gh_pr_description" ]]; then
+		gum log --level error "No description provided"
+		gum log --level info "Usage: gh ai pr comment [PR_NUMBER] -d <DESCRIPTION> [-- OPTIONS]"
+		return 1
+	fi
+
+	# Read optional stdin context
+	local gh_pr_context=""
+	if [[ ! -t 0 ]]; then
+		gh_pr_context=$(cat)
+	fi
+
+	# Fetch PR metadata (title, body, comments)
+	local gh_pr_eval
+	gh_pr_eval=$(gum spin --title "Fetching GitHub pull request #$gh_pr_number metadata..." -- \
+		gh pr view "$gh_pr_number" --json title,body,comments \
+		-q "$(<"$_gh_ai_source_dir/scripts/gh_pr_meta.jq")" || true)
+	if [[ -z "$gh_pr_eval" ]]; then
+		gum log --level error "Failed to fetch PR #$gh_pr_number"
+		return 1
+	fi
+
+	local gh_pr_title gh_pr_body gh_pr_head gh_pr_commits gh_pr_comments
+	eval "$gh_pr_eval"
+
+	local agent_model
+	agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
+
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "pr_body.md" "$gh_pr_body"
+	_save_context_file "$context_dir" "pr_comments.md" "$gh_pr_comments"
+
+	local output
+	# Generate comment content using assistant
+	output=$(
+		if [[ -n "$gh_pr_context" ]]; then
+			_save_context_file "$context_dir" "pr_context.md" "$gh_pr_context"
+			gum spin --title "Generating GitHub pull request #$gh_pr_number comment..." -- \
+				"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
+					GH_PR_NUMBER="$gh_pr_number" \
+						GH_PR_TITLE="$gh_pr_title" \
+						GH_PR_BODY_FILE="$context_dir/pr_body.md" \
+						GH_PR_COMMENTS_FILE="$context_dir/pr_comments.md" \
+						GH_PR_DESCRIPTION="$gh_pr_description" \
+						GH_PR_CONTEXT_FILE="$context_dir/pr_context.md" \
+						"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
+				)
+		else
+			gum spin --title "Generating GitHub pull request #$gh_pr_number comment..." -- \
+				"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
+					GH_PR_NUMBER="$gh_pr_number" \
+						GH_PR_TITLE="$gh_pr_title" \
+						GH_PR_BODY_FILE="$context_dir/pr_body.md" \
+						GH_PR_COMMENTS_FILE="$context_dir/pr_comments.md" \
+						GH_PR_DESCRIPTION="$gh_pr_description" \
+						"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
+				)
+		fi
+	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
+
+	# Validate we got comment content
+	if [[ -z "$output" ]]; then
+		gum log --level error "Failed to generate comment content"
+		gum log --level info "Run with DEBUG=1 for detailed diagnostics"
+		return 1
+	fi
+
+	# Post comment with AI-generated content
+	gh pr comment "$gh_pr_number" --body "$output" "${passthrough[@]}"
+}
+
 # PR explain help function
 #
 # Displays help information for the PR explain command
@@ -990,10 +1188,11 @@ USAGE:
     gh ai pr review [PR_NUMBER] [-d <DESCRIPTION>] [-- GH_PR_REVIEW_OPTIONS]
     gh ai pr explain [PR_NUMBER] [--comment | --edit]
     gh ai pr chat [PR_NUMBER] [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+    gh ai pr comment [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_COMMENT_OPTIONS]
 
 DESCRIPTION:
-    Creates, edits, reviews, and explains GitHub pull requests with AI-generated
-    content. Opens agent sessions with PR context.
+    Creates, edits, reviews, explains, and comments on GitHub pull requests
+    with AI-generated content. Opens agent sessions with PR context.
 
 COMMANDS:
     create      Create PRs with AI-generated titles and descriptions
@@ -1001,6 +1200,7 @@ COMMANDS:
     review      Review PRs with AI-generated feedback
     explain     Generate a plain-language explanation of a PR
     chat        Open an agent session with PR context
+    comment     Post an AI-generated comment on a pull request
 
 SEE ALSO:
     gh ai pr create --help     # Full list of gh pr create options
@@ -1008,6 +1208,7 @@ SEE ALSO:
     gh ai pr review --help     # Full list of gh pr review options
     gh ai pr explain --help    # PR explain usage
     gh ai pr chat --help       # PR chat usage
+    gh ai pr comment --help    # PR comment usage
 EOF
 }
 
@@ -1017,7 +1218,7 @@ EOF
 # Shows help for unknown commands.
 #
 # Usage: _gh_pr <subcommand> [OPTIONS]
-# Subcommands: create, edit, review, explain, chat, help
+# Subcommands: create, edit, review, explain, chat, comment, help
 _gh_pr() {
 	local subcommand="${1:-}"
 	shift || true
@@ -1038,12 +1239,15 @@ _gh_pr() {
 	chat)
 		_gh_pr_chat "$@"
 		;;
+	comment)
+		_gh_pr_comment "$@"
+		;;
 	--help | -h | help | "")
 		_show_pr_help
 		;;
 	*)
 		gum log --level error "Unknown pr command '$subcommand'"
-		gum log --level info "Available commands: create, edit, review, explain, chat"
+		gum log --level info "Available commands: create, edit, review, explain, chat, comment"
 		gum log --level info "Run 'gh ai pr --help' for usage information"
 		return 1
 		;;

--- a/scripts/gh_pr_meta.jq
+++ b/scripts/gh_pr_meta.jq
@@ -1,4 +1,5 @@
 "gh_pr_title=" + (.title // "" | @sh),
 "gh_pr_body=" + (.body // "" | @sh),
 "gh_pr_head=" + (.headRefName // "" | @sh),
-"gh_pr_commits=" + ([.commits[]? | "- " + .messageHeadline] | join("\n") | @sh)
+"gh_pr_commits=" + ([.commits[]? | "- " + .messageHeadline] | join("\n") | @sh),
+"gh_pr_comments=" + ([.comments[]?.body] | join("\n---\n") | @sh)

--- a/templates/gh_pr_comment.tmpl
+++ b/templates/gh_pr_comment.tmpl
@@ -1,0 +1,24 @@
+Write a GitHub pull request comment based on the description below.
+
+<pull_request>
+Number: ${GH_PR_NUMBER}
+Title: ${GH_PR_TITLE}
+Body: ${GH_PR_BODY}
+</pull_request>
+
+<comments>
+${GH_PR_COMMENTS}
+</comments>
+
+<context>
+${GH_PR_CONTEXT}
+</context>
+
+${GH_PR_DESCRIPTION}
+
+<format>
+- Body: GitHub-flavored Markdown; reference code as `file.ext:line` when relevant
+- Be specific and actionable; omit sections that do not apply; do not write "N/A"
+- Output only the comment body, no preamble or meta-commentary
+- Wrap prose paragraphs at 120 characters; do not wrap headings, code blocks, inline code, or URLs
+</format>

--- a/templates/gh_pr_comment.tmpl
+++ b/templates/gh_pr_comment.tmpl
@@ -1,4 +1,5 @@
-Write a GitHub pull request comment based on the description below.
+Write a conversational GitHub pull request comment that fulfils the request below.
+Do not write a code review — produce a natural, targeted comment for the PR conversation.
 
 <pull_request>
 Number: ${GH_PR_NUMBER}
@@ -14,11 +15,14 @@ ${GH_PR_COMMENTS}
 ${GH_PR_CONTEXT}
 </context>
 
+<request>
 ${GH_PR_DESCRIPTION}
+</request>
 
 <format>
-- Body: GitHub-flavored Markdown; reference code as `file.ext:line` when relevant
-- Be specific and actionable; omit sections that do not apply; do not write "N/A"
+- Body: GitHub-flavored Markdown
+- Match the tone and scope of the request — keep it concise and conversational
+- Omit sections that do not apply; do not write "N/A"
 - Output only the comment body, no preamble or meta-commentary
 - Wrap prose paragraphs at 120 characters; do not wrap headings, code blocks, inline code, or URLs
 </format>

--- a/templates/gh_pr_create.tmpl
+++ b/templates/gh_pr_create.tmpl
@@ -13,7 +13,9 @@ ${GH_PR_DIFF}
 ${GH_PR_COMMITS}
 </commits>
 
+<description>
 ${GH_PR_DESCRIPTION}
+</description>
 
 <format>
 - First line: PR title — imperative mood, under 72 chars, no trailing period

--- a/templates/gh_pr_create.tmpl
+++ b/templates/gh_pr_create.tmpl
@@ -9,15 +9,9 @@ ${GH_PR_DIFF_STAT}
 ${GH_PR_DIFF}
 </diff>
 
-<log>
-${GH_PR_LOG}
-</log>
-
-<context>
-<recent_commits>
+<commits>
 ${GH_PR_COMMITS}
-</recent_commits>
-</context>
+</commits>
 
 ${GH_PR_DESCRIPTION}
 

--- a/templates/gh_pr_explain.tmpl
+++ b/templates/gh_pr_explain.tmpl
@@ -6,9 +6,9 @@ Title: ${GH_PR_TITLE}
 Branch: ${GH_PR_HEAD}
 </pr>
 
-<current_description>
+<description>
 ${GH_PR_BODY}
-</current_description>
+</description>
 
 <diffstat>
 ${GH_PR_DIFF_STAT}
@@ -18,11 +18,9 @@ ${GH_PR_DIFF_STAT}
 ${GH_PR_DIFF}
 </diff>
 
-<context>
-<recent_commits>
+<commits>
 ${GH_PR_COMMITS}
-</recent_commits>
-</context>
+</commits>
 
 <format>
 - Focus on *what* changed and *why*, not low-level code details

--- a/templates/gh_pr_review.tmpl
+++ b/templates/gh_pr_review.tmpl
@@ -13,11 +13,9 @@ ${GH_PR_DIFF_STAT}
 ${GH_PR_DIFF}
 </diff>
 
-<context>
-<recent_commits>
+<commits>
 ${GH_PR_COMMITS}
-</recent_commits>
-</context>
+</commits>
 
 ${GH_PR_DESCRIPTION}
 

--- a/tests/gh_pr_comment.bats
+++ b/tests/gh_pr_comment.bats
@@ -1,0 +1,247 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh ai pr comment arg parsing
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_pr_comment.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+
+	# Mock external commands not under test
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
+	gh() { echo ""; }
+	git() { echo ""; }
+	export -f gum gh git
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		# shellcheck source=../scripts/gh_pr.sh
+		source "$REPO_ROOT/scripts/gh_pr.sh"
+		declare -f _parse_pr_comment_args _show_pr_comment_help _gh_pr_comment _split_on_separator _create_context_dir _save_context_file
+	)"
+}
+
+@test "_parse_pr_comment_args: sets description from -d flag" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description -d "summarise open threads"
+
+	[[ "$description" == "summarise open threads" ]]
+}
+
+@test "_parse_pr_comment_args: sets description from --description flag" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description --description "ask about migration"
+
+	[[ "$description" == "ask about migration" ]]
+}
+
+@test "_parse_pr_comment_args: sets description from --description=value" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description --description="request changes"
+
+	[[ "$description" == "request changes" ]]
+}
+
+@test "_parse_pr_comment_args: captures both PR number and description" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description 42 -d "summarise open threads"
+
+	[[ "$number" == "42" ]]
+	[[ "$description" == "summarise open threads" ]]
+}
+
+@test "_parse_pr_comment_args: strips leading # from PR number" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description "#42" -d "context"
+
+	[[ "$number" == "42" ]]
+}
+
+@test "_parse_pr_comment_args: accepts PR number without description flag" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description 99
+
+	[[ "$number" == "99" ]]
+	[[ -z "$description" ]]
+}
+
+@test "_parse_pr_comment_args: accepts empty string for -d" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description -d ""
+
+	[[ -z "$description" ]]
+}
+
+@test "_parse_pr_comment_args: preserves special characters in description" {
+	local number=""
+	local description=""
+	local expected='fix: handle $HOME and '"'"'quotes'"'"' & <html>'
+	_parse_pr_comment_args number description -d "$expected"
+
+	[[ "$description" == "$expected" ]]
+}
+
+@test "_parse_pr_comment_args: defaults to empty when no flags given" {
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description
+
+	[[ -z "$number" ]]
+	[[ -z "$description" ]]
+}
+
+@test "_parse_pr_comment_args: returns error when -d has no value" {
+	local number=""
+	local description=""
+	run _parse_pr_comment_args number description -d
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_parse_pr_comment_args: returns error when --description has no value" {
+	local number=""
+	local description=""
+	run _parse_pr_comment_args number description --description
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_parse_pr_comment_args: returns error with hint for unknown flags" {
+	local number=""
+	local description=""
+	run _parse_pr_comment_args number description --approve
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"use -- to pass flags to gh pr comment"* ]]
+}
+
+@test "_parse_pr_comment_args: returns error for unexpected non-numeric argument" {
+	local number=""
+	local description=""
+	run _parse_pr_comment_args number description somebranch
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_parse_pr_comment_args: auto-detects PR from current branch" {
+	gh() {
+		if [[ "$*" == *"pr view"* && "$*" == *"--json number"* ]]; then
+			echo "7"
+		else
+			echo ""
+		fi
+	}
+	export -f gh
+
+	local number=""
+	local description=""
+	_parse_pr_comment_args number description -d "context"
+
+	[[ "$number" == "7" ]]
+}
+
+@test "_show_pr_comment_help: prints expected help text" {
+	run _show_pr_comment_help
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"gh ai pr comment"* ]]
+	[[ "$output" == *"-d, --description"* ]]
+	[[ "$output" == *"gh ai pr comment 42 -d"* ]]
+}
+
+@test "_gh_pr_comment: shows help with --help" {
+	run _gh_pr_comment --help
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"gh ai pr comment"* ]]
+}
+
+@test "_gh_pr_comment: shows help with -h" {
+	run _gh_pr_comment -h
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"gh ai pr comment"* ]]
+}
+
+@test "_gh_pr_comment: errors when no PR number and auto-detect fails" {
+	gh() { echo ""; }
+	export -f gh
+
+	run _gh_pr_comment -d "some description"
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"No PR number provided"* ]]
+}
+
+@test "_gh_pr_comment: errors when no description provided" {
+	gh() {
+		if [[ "$*" == *"pr view"* && "$*" == *"--json number"* ]]; then
+			echo "42"
+		else
+			echo ""
+		fi
+	}
+	export -f gh
+
+	run _gh_pr_comment 42
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"No description provided"* ]]
+}
+
+@test "_gh_pr_comment: errors when metadata fetch fails" {
+	gum() {
+		if [[ "$1" == "spin" ]]; then
+			echo ""
+		elif [[ "$1" == "log" ]]; then
+			shift; shift; shift; echo "$@"
+		fi
+	}
+	export -f gum
+
+	run _gh_pr_comment 42 -d "context"
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"Failed to fetch PR"* ]]
+}
+
+@test "_gh_pr_comment: passes passthrough args to gh pr comment" {
+	# Verify that args after -- are not consumed by the parser
+	local number=""
+	local description=""
+	local ai_args=()
+	local passthrough=()
+
+	# Simulate _split_on_separator behaviour inline
+	local found_sep=false
+	for arg in 42 -d "comment text" -- --edit-last; do
+		if [[ "$arg" == "--" ]]; then
+			found_sep=true
+			continue
+		fi
+		if $found_sep; then
+			passthrough+=("$arg")
+		else
+			ai_args+=("$arg")
+		fi
+	done
+
+	_parse_pr_comment_args number description "${ai_args[@]}"
+
+	[[ "$number" == "42" ]]
+	[[ "$description" == "comment text" ]]
+	[[ "${passthrough[0]}" == "--edit-last" ]]
+}


### PR DESCRIPTION
## Summary

Introduce a new `gh ai pr comment` subcommand that posts AI-generated comments on pull requests. The command fetches PR
metadata (title, body, existing comments), renders a prompt template with user-provided context, and posts the generated
response as a PR comment. Supporting changes simplify XML tag naming in existing templates and extend the jq metadata
script to extract comments.

## Risk Level

**Low** — Additive feature with no changes to existing subcommand behavior; template tag renames are cosmetic and
consistent across all templates.

## Changes

### Behavior & Execution Flow

`gh ai pr comment [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_COMMENT_OPTIONS]` parses its own arguments via
`_parse_pr_comment_args`, auto-detects the PR number from the current branch when omitted, fetches PR metadata including
comments via `gh pr view`, renders `gh_pr_comment.tmpl` through the AI provider, and posts the result with
`gh pr comment`. Optional stdin content is saved as an additional context file and injected into the prompt. Arguments
after `--` are forwarded directly to `gh pr comment` (e.g., `--edit-last`).

### Design Decisions

- **Dedicated argument parser** (`_parse_pr_comment_args`): Mirrors the pattern used by `_gh_pr_review` but requires
  `-d`/`--description` and treats unknown flags as errors with a hint to use `--`, reducing user confusion.
- **Comments in jq metadata**: `gh_pr_meta.jq` now emits `gh_pr_comments` joined by `---` separators, making the field
  available to all subcommands without breaking existing consumers that simply ignore it.
- **Template tag simplification**: Renamed `<recent_commits>` → `<commits>` and `<current_description>` → `<description>`
  across `gh_pr_create.tmpl`, `gh_pr_explain.tmpl`, and `gh_pr_review.tmpl` for consistency with the new template. The
  `<log>` section was removed from `gh_pr_create.tmpl` as it duplicated commit information.

### Edge Cases

- PR number accepts an optional `#` prefix (`#42` → `42`) in `_parse_pr_comment_args`.
- `-d` with a missing value or unknown flags return non-zero with descriptive error messages.
- When `gh pr view --json number` fails during auto-detect, the variable stays empty and the caller produces a clear
  error before any AI call is made.
- Empty AI output after generation is caught and surfaced as an error with a `DEBUG=1` hint.

## Testing

Run the new test suite:

```sh
bats tests/gh_pr_comment.bats
```

`tests/gh_pr_comment.bats` (247 lines) covers:

- `-d`, `--description`, and `--description=value` parsing
- PR number extraction with and without `#` prefix
- Auto-detection fallback via mocked `gh pr view`
- Error paths: missing `-d` value, unknown flags, non-numeric arguments, failed metadata fetch, missing description
- Help output for `--help`, `-h`, and `help`
- Passthrough argument splitting across `--`

## Impact

- **Breaking Changes:** No — existing subcommands are unchanged; template tag renames only affect internal prompt text
  sent to the AI provider
- **Performance:** No change
- **Security:** No new trust boundaries; stdin and description values flow through the same template-rendering and
  context-file pipeline as existing subcommands

<!-- markdownlint-disable-file MD013 MD022 MD041 MD047 -->