### PR TITLE
Add `gh ai issue comment` command for AI-generated issue comments

### DIFF
--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -17,23 +17,27 @@ gh ai issue - Issue commands with AI assistance
 USAGE:
     gh ai issue create -d <DESCRIPTION> [-- GH_ISSUE_CREATE_OPTIONS]
     gh ai issue edit <ISSUE_NUMBER> -d <DESCRIPTION> [-- GH_ISSUE_EDIT_OPTIONS]
+    gh ai issue comment <ISSUE_NUMBER> -d <DESCRIPTION> [-- GH_ISSUE_COMMENT_OPTIONS]
     gh ai issue plan <ISSUE_NUMBER>
     gh ai issue chat <ISSUE_NUMBER> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
 
 DESCRIPTION:
     Creates and edits GitHub issues with AI-generated titles and structured
-    bodies. Generates implementation plans from issues and prints them to stdout.
+    bodies. Posts AI-generated comments on existing issues. Generates
+    implementation plans from issues and prints them to stdout.
     Opens agent sessions with issue context.
 
 COMMANDS:
     create      Create issues with AI-generated content
     edit        Edit an existing issue with AI-generated content
+    comment     Post an AI-generated comment on an existing issue
     plan        Generate an AI implementation plan from an issue
     chat        Open an agent session with issue context
 
 SEE ALSO:
     gh ai issue create --help     # Issue create usage
     gh ai issue edit --help       # Issue edit usage
+    gh ai issue comment --help    # Issue comment usage
     gh ai issue plan --help       # Issue plan usage
     gh ai issue chat --help       # Issue chat usage
 EOF
@@ -122,6 +126,59 @@ _parse_issue_edit_args() {
 			;;
 		-*)
 			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh issue edit)"
+			return 1
+			;;
+		*)
+			local arg="${raw_args[$i]#\#}"
+			if [[ -z "$gh_issue_number_ref" && "$arg" =~ ^[0-9]+$ ]]; then
+				gh_issue_number_ref="$arg"
+			else
+				gum log --level error "unexpected argument '${raw_args[$i]}'"
+				return 1
+			fi
+			;;
+		esac
+		((++i))
+	done
+}
+
+# Parse issue comment arguments (before -- separator)
+#
+# Extracts the issue number (first numeric positional arg) and -d/--description value.
+# Unknown flags produce an error with a hint to use --.
+#
+# Example: _parse_issue_comment_args num desc 42 -d "post a status update"
+_parse_issue_comment_args() {
+	local -n gh_issue_number_ref="$1"
+	local -n gh_issue_description_ref="$2"
+	shift 2
+
+	local raw_args=("$@")
+	local skip_next=false
+	local i=0
+
+	while [[ $i -lt ${#raw_args[@]} ]]; do
+		if [ "$skip_next" = true ]; then
+			skip_next=false
+			((++i))
+			continue
+		fi
+
+		case "${raw_args[$i]}" in
+		--description | -d)
+			if ((i + 1 >= ${#raw_args[@]})); then
+				gum log --level error "${raw_args[$i]} requires a value"
+				return 1
+			fi
+			gh_issue_description_ref="${raw_args[$((i + 1))]}"
+			skip_next=true
+			;;
+		--description=*)
+			# shellcheck disable=SC2034 # nameref: set by caller
+			gh_issue_description_ref="${raw_args[$i]#--description=}"
+			;;
+		-*)
+			gum log --level error "unknown flag '${raw_args[$i]}' (use -- to pass flags to gh issue comment)"
 			return 1
 			;;
 		*)
@@ -279,6 +336,140 @@ _gh_issue_edit() {
 
 	# Edit issue with AI-generated content
 	gh issue edit "$gh_issue_number" --title "$gh_issue_new_title" --body "$gh_issue_new_body" "${passthrough[@]}"
+}
+
+# Issue comment help function
+#
+# Displays help information for the issue comment command
+# including usage examples and available options.
+_show_issue_comment_help() {
+	cat <<'EOF'
+gh ai issue comment - Post an AI-generated comment on an existing issue
+
+USAGE:
+    gh ai issue comment <ISSUE_NUMBER> -d <DESCRIPTION> [-- GH_ISSUE_COMMENT_OPTIONS]
+
+DESCRIPTION:
+    Posts an AI-generated comment on an existing GitHub issue. Fetches the
+    current issue content and existing comments for context, generates the
+    comment body via AI, and posts it. Supports piped stdin as additional
+    context. Options after -- are passed directly to gh issue comment.
+
+FLAGS:
+    -d, --description string   Instructions for the comment (required)
+
+EXAMPLES:
+    gh ai issue comment 42 -d "post a status update: implementation is in progress"
+    gh ai issue comment 42 -d "acknowledge the report and ask for more details"
+    gh ai issue comment 42 -d "summarize the discussion so far"
+    echo "error: connection refused" | gh ai issue comment 42 -d "add this error as context"
+    some_command 2>&1 | gh ai issue comment 42 -d "add the output as context"
+    gh ai issue comment 42 -d "acknowledge the report" -- --edit
+EOF
+}
+
+# Issue Comment implementation
+#
+# Posts an AI-generated comment on an existing GitHub issue.
+# Fetches the current issue, renders a prompt template with the
+# description and issue context, sends it to the AI provider,
+# and posts the comment.
+# Supports piped stdin as additional context.
+#
+# Usage: _gh_issue_comment <NUMBER> -d <DESCRIPTION> [-- OPTIONS]
+_gh_issue_comment() {
+	case "${1:-}" in
+	--help | -h | help)
+		_show_issue_comment_help
+		return 0
+		;;
+	esac
+
+	local ai_args=()
+	local passthrough=()
+	_split_on_separator ai_args passthrough "$@"
+
+	local template_file
+	# shellcheck disable=SC2154
+	template_file="$_gh_ai_source_dir/templates/gh_issue_comment.tmpl"
+
+	local gh_issue_number=""
+	local gh_issue_description=""
+	_parse_issue_comment_args gh_issue_number gh_issue_description "${ai_args[@]}"
+
+	if [[ -z "$gh_issue_number" ]]; then
+		gum log --level error "No issue number provided"
+		gum log --level info "Usage: gh ai issue comment <ISSUE_NUMBER> -d <DESCRIPTION> [-- OPTIONS]"
+		return 1
+	fi
+
+	if [[ -z "$gh_issue_description" ]]; then
+		gum log --level error "No description provided"
+		gum log --level info "Usage: gh ai issue comment <ISSUE_NUMBER> -d <DESCRIPTION> [-- OPTIONS]"
+		return 1
+	fi
+
+	# Read piped stdin context if available
+	local gh_issue_context=""
+	if [[ ! -t 0 ]]; then
+		gh_issue_context=$(cat)
+	fi
+
+	# Fetch issue metadata
+	local gh_issue_eval
+	gh_issue_eval=$(gum spin --title "Fetching GitHub issue #$gh_issue_number metadata..." -- \
+		gh issue view "$gh_issue_number" --json title,body,labels,comments \
+		-q "$(<"$_gh_ai_source_dir/scripts/gh_issue_meta.jq")" || true)
+	if [[ -z "$gh_issue_eval" ]]; then
+		gum log --level error "Failed to fetch issue #$gh_issue_number"
+		return 1
+	fi
+
+	local gh_issue_title gh_issue_body gh_issue_labels gh_issue_comments
+	eval "$gh_issue_eval"
+
+	local agent_model
+	agent_model=$(gh config get ai.issue.model 2>/dev/null || true)
+
+	# Create context directory and save large content to files
+	local context_dir
+	_create_context_dir context_dir
+	_save_context_file "$context_dir" "issue_body.md" "$gh_issue_body"
+	_save_context_file "$context_dir" "issue_comments.md" "$gh_issue_comments"
+	local render_env=()
+	if [[ -n "$gh_issue_context" ]]; then
+		_save_context_file "$context_dir" "issue_context.md" "$gh_issue_context"
+		render_env+=(GH_ISSUE_CONTEXT_FILE="$context_dir/issue_context.md")
+	fi
+
+	local output
+	# Generate comment using assistant
+	output=$(
+		gum spin --title "Generating comment for GitHub issue #$gh_issue_number..." -- \
+			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$agent_model" < <(
+				GH_ISSUE_NUMBER="$gh_issue_number" \
+					GH_ISSUE_TITLE="$gh_issue_title" \
+					GH_ISSUE_BODY_FILE="$context_dir/issue_body.md" \
+					GH_ISSUE_LABELS="$gh_issue_labels" \
+					GH_ISSUE_COMMENTS_FILE="$context_dir/issue_comments.md" \
+					GH_ISSUE_DESCRIPTION="$gh_issue_description" \
+					"${render_env[@]}" \
+					"$_gh_ai_source_dir/scripts/gh_cmd.sh" render "$template_file"
+			)
+	)
+
+	# Clean up temp context directory
+	rm -rf "$context_dir"
+
+	# Validate we got comment content
+	if [[ -z "$output" ]]; then
+		gum log --level error "Failed to generate comment"
+		gum log --level info "Run with DEBUG=1 for detailed diagnostics"
+		return 1
+	fi
+
+	# Post comment with AI-generated content
+	gh issue comment "$gh_issue_number" --body "$output" "${passthrough[@]}"
 }
 
 # Parse issue plan arguments
@@ -760,6 +951,9 @@ _gh_issue() {
 	edit)
 		_gh_issue_edit "$@"
 		;;
+	comment)
+		_gh_issue_comment "$@"
+		;;
 	plan)
 		_gh_issue_plan "$@"
 		;;
@@ -771,7 +965,7 @@ _gh_issue() {
 		;;
 	*)
 		gum log --level error "Unknown issue command '$subcommand'"
-		gum log --level info "Available commands: create, edit, plan, chat"
+		gum log --level info "Available commands: create, edit, plan, chat, comment"
 		gum log --level info "Run 'gh ai issue --help' for usage information"
 		return 1
 		;;

--- a/templates/gh_issue_chat.tmpl
+++ b/templates/gh_issue_chat.tmpl
@@ -6,11 +6,11 @@ Title: ${GH_ISSUE_TITLE}
 Labels: ${GH_ISSUE_LABELS}
 </issue>
 
-<context-files>
+<context_files>
 The following files contain detailed context for this issue:
 - ${GH_SESSION_DIR}/issue_body.md — issue body
 - ${GH_SESSION_DIR}/issue_comments.md — all comments
-</context-files>
+</context_files>
 
 ${GH_ISSUE_FOCUS}
 

--- a/templates/gh_issue_comment.tmpl
+++ b/templates/gh_issue_comment.tmpl
@@ -1,0 +1,26 @@
+Write a comment for the following GitHub issue based on the requested instructions.
+
+<issue>
+Number: ${GH_ISSUE_NUMBER}
+Title: ${GH_ISSUE_TITLE}
+Body: ${GH_ISSUE_BODY}
+Labels: ${GH_ISSUE_LABELS}
+</issue>
+
+<comments>
+${GH_ISSUE_COMMENTS}
+</comments>
+
+<description>
+${GH_ISSUE_DESCRIPTION}
+</description>
+
+<additional_context>
+${GH_ISSUE_CONTEXT}
+</additional_context>
+
+<format>
+- Output only the comment body, no preamble or commentary
+- Use GitHub-flavored Markdown
+- Wrap prose paragraphs at 120 characters; do not wrap headings, code blocks, inline code, or URLs
+</format>

--- a/tests/gh_issue_comment.bats
+++ b/tests/gh_issue_comment.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+# Unit tests for gh ai issue comment arg parsing
+#
+# Requires bats-core: https://github.com/bats-core/bats-core
+# Run: bats tests/gh_issue_comment.bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+
+setup() {
+	export _gh_ai_source_dir="$REPO_ROOT"
+
+	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
+	gh() { echo ""; }
+	git() { echo ""; }
+	export -f gum gh git
+
+	# shellcheck disable=SC2155
+	eval "$(
+		export _gh_ai_source_dir="$REPO_ROOT"
+		# shellcheck source=../scripts/gh_cmd.sh
+		source "$REPO_ROOT/scripts/gh_cmd.sh"
+		# shellcheck source=../scripts/gh_issue.sh
+		source "$REPO_ROOT/scripts/gh_issue.sh"
+		declare -f _parse_issue_comment_args _show_issue_comment_help _gh_issue_comment _split_on_separator
+	)"
+}
+
+@test "_parse_issue_comment_args: sets description from -d flag" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description -d "post a status update"
+
+	[[ "$description" == "post a status update" ]]
+}
+
+@test "_parse_issue_comment_args: sets description from --description flag" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description --description "acknowledge the report"
+
+	[[ "$description" == "acknowledge the report" ]]
+}
+
+@test "_parse_issue_comment_args: sets description from --description=value" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description --description="acknowledge the report"
+
+	[[ "$description" == "acknowledge the report" ]]
+}
+
+@test "_parse_issue_comment_args: captures issue number from first positional arg" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description 42 -d "post a status update"
+
+	[[ "$number" == "42" ]]
+	[[ "$description" == "post a status update" ]]
+}
+
+@test "_parse_issue_comment_args: strips leading # from issue number" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description "#42" -d "post a status update"
+
+	[[ "$number" == "42" ]]
+}
+
+@test "_parse_issue_comment_args: captures issue number without other flags" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description 42
+
+	[[ "$number" == "42" ]]
+}
+
+@test "_parse_issue_comment_args: defaults number and description to empty" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description
+
+	[[ -z "$description" ]]
+	[[ -z "$number" ]]
+}
+
+@test "_parse_issue_comment_args: preserves special characters in description" {
+	local number=""
+	local description=""
+	local expected='fix: handle $HOME and '"'"'quotes'"'"' & <html>'
+	_parse_issue_comment_args number description -d "$expected"
+
+	[[ "$description" == "$expected" ]]
+}
+
+@test "_parse_issue_comment_args: last value wins when -d and --description both given" {
+	local number=""
+	local description=""
+	_parse_issue_comment_args number description -d "first" --description="second"
+
+	[[ "$description" == "second" ]]
+}
+
+@test "_parse_issue_comment_args: returns error when -d has no value" {
+	local number=""
+	local description=""
+	run _parse_issue_comment_args number description -d
+
+	[[ "$status" -eq 1 ]]
+}
+
+@test "_parse_issue_comment_args: returns error with hint for unknown flags" {
+	local number=""
+	local description=""
+	run _parse_issue_comment_args number description --edit
+
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *"use -- to pass flags to gh issue comment"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a new `comment` subcommand to `gh ai issue` that posts AI-generated comments on existing GitHub issues. The command
fetches the current issue content and existing comments for context, renders a prompt template, generates a comment body
via the AI provider, and posts it. Piped stdin is supported as additional context.

## Risk Level

**Low** — This is a purely additive feature following the same patterns established by the existing `create` and `edit`
subcommands, with no changes to existing behavior beyond a minor tag rename in the chat template.

## Changes

### Behavior & Execution Flow

The new `comment` subcommand (`gh ai issue comment <NUMBER> -d <DESCRIPTION> [-- OPTIONS]`) fetches issue metadata
(title, body, labels, comments) via `gh issue view`, saves large content to temporary context files, renders
`templates/gh_issue_comment.tmpl` with the issue context and user description, sends the rendered prompt to the AI
provider, and posts the resulting output via `gh issue comment`. Any flags after `--` are passed through directly to `gh
issue comment` (e.g., `--edit`). Piped stdin is captured and injected as additional context via `GH_ISSUE_CONTEXT_FILE`.

### Design Decisions

- **Mirrors existing `create`/`edit` architecture:** `_parse_issue_comment_args`, `_show_issue_comment_help`, and
  `_gh_issue_comment` follow the same structure and conventions as their counterparts, reducing cognitive overhead.
- **Unknown flags error with hint:** `_parse_issue_comment_args` rejects unknown flags with a message suggesting `--` to
  pass them through, matching the edit parser behavior.
- **Context file pattern:** Large content (body, comments, piped stdin) is written to temporary files and referenced by
  environment variables, consistent with the existing context directory pattern in `_gh_issue_edit`.
- **Template uses inline env vars:** `gh_issue_comment.tmpl` uses `${GH_ISSUE_BODY}` / `${GH_ISSUE_COMMENTS}` directly
  (rendered from file contents), keeping the template self-contained for the non-chat single-shot flow.
- **Tag rename in `gh_issue_chat.tmpl`:** Changed `<context-files>` to `<context_files>` for consistency with XML-style
  tag naming conventions used elsewhere.

### Edge Cases

- Missing issue number or description produces a clear error with usage hint (`scripts/gh_issue.sh:403-412`).
- `-d` without a value returns an error (`_parse_issue_comment_args` bounds check at `scripts/gh_issue.sh:171-174`).
- Issue number with leading `#` is stripped (`scripts/gh_issue.sh:188`).
- Empty AI output is caught and reported with a debug hint (`scripts/gh_issue.sh:462-465`).
- Non-TTY stdin is consumed as additional context; TTY stdin is left untouched (`scripts/gh_issue.sh:417-419`).

## Testing

Run the argument parsing tests:

```sh
bats tests/gh_issue_comment.bats
```

The test suite (`tests/gh_issue_comment.bats`) covers 11 cases: `-d` and `--description` variants, `--description=`
form, positional issue number extraction, `#`-prefix stripping, empty defaults, special characters in descriptions,
last-value-wins semantics, missing `-d` value error, and unknown flag rejection with hint message.

Manual verification:

```sh
gh ai issue comment 42 -d "acknowledge the report and ask for more details"
echo "error log output" | gh ai issue comment 42 -d "add this error as context"
gh ai issue comment 42 -d "summarize discussion" -- --edit
gh ai issue comment --help
```

## Impact

- **Breaking Changes:** No — the only non-additive change is the `<context-files>` → `<context_files>` tag rename in
  `gh_issue_chat.tmpl`, which is an internal template consumed by the AI provider and not a user-facing contract.
- **Performance:** No change
- **Security:** Piped stdin and issue content are written to temporary files in a `mktemp`-created directory and cleaned
  up after use. All user input flows through the existing template rendering and AI provider pipeline.

<!-- markdownlint-disable-file MD013 MD022 MD041 MD047 -->