### PR TITLE
feat: include PR and issue URLs in templates

### DIFF
--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -75,17 +75,18 @@ _parse_issue_args() {
 # .claude/sessions/issue-<num> so Claude can resume across invocations.
 # For all other types a temporary directory is created.
 #
-# Usage: _prepare_issue_context type issue_number dir_ref title_ref labels_ref
+# Usage: _prepare_issue_context type issue_number dir_ref title_ref labels_ref url_ref
 _prepare_issue_context() {
 	local _ctx_type="$1"
 	local _ctx_num="$2"
 	local -n _ctx_dir="$3"
 	local -n _ctx_title="$4"
 	local -n _ctx_labels="$5"
+	local -n _ctx_url="$6"
 
 	local _ctx_meta
 	_ctx_meta=$(gum spin --title "Fetching GitHub issue #$_ctx_num metadata..." -- \
-		gh issue view "$_ctx_num" --json title,body,labels,comments || true)
+		gh issue view "$_ctx_num" --json title,body,labels,comments,url || true)
 	if [[ -z "$_ctx_meta" ]]; then
 		gum log --level error "Failed to fetch issue #$_ctx_num"
 		return 1
@@ -351,8 +352,8 @@ _gh_issue_edit() {
 		return 1
 	fi
 
-	local gh_issue_dir="" gh_issue_title="" gh_issue_labels=""
-	_prepare_issue_edit_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels || return 1
+	local gh_issue_dir="" gh_issue_title="" gh_issue_labels="" gh_issue_url=""
+	_prepare_issue_edit_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels gh_issue_url || return 1
 
 	local gh_issue_agent_model
 	gh_issue_agent_model=$(gh config get ai.issue.model 2>/dev/null || true)
@@ -365,6 +366,7 @@ _gh_issue_edit() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$gh_issue_agent_model" < <(
 				GH_ISSUE_NUMBER="$gh_issue_number" \
 					GH_ISSUE_TITLE="$gh_issue_title" \
+					GH_ISSUE_URL="$gh_issue_url" \
 					GH_ISSUE_BODY_FILE="$gh_issue_dir/issue_body.md" \
 					GH_ISSUE_LABELS="$gh_issue_labels" \
 					GH_ISSUE_COMMENTS_FILE="$gh_issue_dir/issue_comments.md" \
@@ -475,8 +477,8 @@ _gh_issue_comment() {
 		return 1
 	fi
 
-	local gh_issue_dir="" gh_issue_title="" gh_issue_labels=""
-	_prepare_issue_comment_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels || return 1
+	local gh_issue_dir="" gh_issue_title="" gh_issue_labels="" gh_issue_url=""
+	_prepare_issue_comment_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels gh_issue_url || return 1
 
 	local gh_issue_agent_model
 	gh_issue_agent_model=$(gh config get ai.issue.model 2>/dev/null || true)
@@ -489,6 +491,7 @@ _gh_issue_comment() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$gh_issue_agent_model" < <(
 				GH_ISSUE_NUMBER="$gh_issue_number" \
 					GH_ISSUE_TITLE="$gh_issue_title" \
+					GH_ISSUE_URL="$gh_issue_url" \
 					GH_ISSUE_BODY_FILE="$gh_issue_dir/issue_body.md" \
 					GH_ISSUE_LABELS="$gh_issue_labels" \
 					GH_ISSUE_COMMENTS_FILE="$gh_issue_dir/issue_comments.md" \
@@ -577,8 +580,8 @@ _gh_issue_plan() {
 		return 1
 	fi
 
-	local gh_issue_dir="" gh_issue_title="" gh_issue_labels=""
-	_prepare_issue_plan_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels || return 1
+	local gh_issue_dir="" gh_issue_title="" gh_issue_labels="" gh_issue_url=""
+	_prepare_issue_plan_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels gh_issue_url || return 1
 
 	local gh_issue_agent_model
 	gh_issue_agent_model=$(gh config get ai.issue.model 2>/dev/null || true)
@@ -596,6 +599,7 @@ _gh_issue_plan() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$gh_issue_agent_model" < <(
 				GH_ISSUE_NUMBER="$gh_issue_number" \
 					GH_ISSUE_TITLE="$gh_issue_title" \
+					GH_ISSUE_URL="$gh_issue_url" \
 					GH_ISSUE_BODY_FILE="$gh_issue_dir/issue_body.md" \
 					GH_ISSUE_LABELS="$gh_issue_labels" \
 					GH_ISSUE_COMMENTS_FILE="$gh_issue_dir/issue_comments.md" \
@@ -692,8 +696,8 @@ _gh_issue_chat() {
 		return 1
 	fi
 
-	local gh_issue_dir="" gh_issue_title="" gh_issue_labels=""
-	_prepare_issue_chat_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels || return 1
+	local gh_issue_dir="" gh_issue_title="" gh_issue_labels="" gh_issue_url=""
+	_prepare_issue_chat_context "$gh_issue_number" gh_issue_dir gh_issue_title gh_issue_labels gh_issue_url || return 1
 
 	local gh_issue_focus=""
 	if [[ -n "$gh_issue_description" ]]; then
@@ -712,6 +716,7 @@ _gh_issue_chat() {
 		gh_issue_preamble=$(
 			GH_ISSUE_NUMBER="$gh_issue_number" \
 				GH_ISSUE_TITLE="$gh_issue_title" \
+				GH_ISSUE_URL="$gh_issue_url" \
 				GH_ISSUE_LABELS="$gh_issue_labels" \
 				GH_ISSUE_FOCUS="$gh_issue_focus" \
 				GH_SESSION_DIR="$gh_issue_dir" \

--- a/scripts/gh_issue_meta.jq
+++ b/scripts/gh_issue_meta.jq
@@ -1,4 +1,5 @@
 "_ctx_title=" + ((.title // "") | @sh),
 "_ctx_labels=" + (([(.labels // [])[].name] | join(", ")) | @sh),
 "_ctx_body=" + ((.body // "") | @sh),
-"_ctx_comments=" + (([(.comments // [])[].body] | join("\n---\n")) | @sh)
+"_ctx_comments=" + (([(.comments // [])[].body] | join("\n---\n")) | @sh),
+"_ctx_url=" + ((.url // "") | @sh)

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -85,17 +85,18 @@ _parse_pr_args() {
 # .claude/sessions/pull-<num> so Claude can resume across invocations.
 # For all other types a temporary directory is created.
 #
-# Usage: _prepare_pr_diff_context type pr_number dir_ref title_ref head_ref
+# Usage: _prepare_pr_diff_context type pr_number dir_ref title_ref head_ref url_ref
 _prepare_pr_diff_context() {
 	local _ctx_type="$1"
 	local _ctx_num="$2"
 	local -n _ctx_dir="$3"
 	local -n _ctx_title="$4"
 	local -n _ctx_head="$5"
+	local -n _ctx_url="$6"
 
 	local _ctx_meta
 	_ctx_meta=$(gum spin --title "Fetching GitHub pull request #$_ctx_num metadata..." -- \
-		gh pr view "$_ctx_num" --json title,body,headRefName,commits || true)
+		gh pr view "$_ctx_num" --json title,body,headRefName,commits,url || true)
 	if [[ -z "$_ctx_meta" ]]; then
 		gum log --level error "Failed to fetch pull request #$_ctx_num metadata"
 		return 1
@@ -394,8 +395,8 @@ _gh_pr_edit() {
 		return 1
 	fi
 
-	local gh_pr_dir="" gh_pr_title="" gh_pr_head=""
-	_prepare_pr_edit_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head || return 1
+	local gh_pr_dir="" gh_pr_title="" gh_pr_head="" gh_pr_url=""
+	_prepare_pr_edit_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head gh_pr_url || return 1
 
 	local gh_pr_agent_model
 	gh_pr_agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
@@ -408,6 +409,7 @@ _gh_pr_edit() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$gh_pr_agent_model" < <(
 				GH_PR_NUMBER="$gh_pr_number" \
 					GH_PR_TITLE="$gh_pr_title" \
+					GH_PR_URL="$gh_pr_url" \
 					GH_PR_DIFF_FILE="$gh_pr_dir/pr_diff.patch" \
 					GH_PR_DIFF_STAT_FILE="$gh_pr_dir/pr_diff_stat.txt" \
 					GH_PR_COMMITS_FILE="$gh_pr_dir/pr_commits.txt" \
@@ -510,8 +512,8 @@ _gh_pr_review() {
 		return 1
 	fi
 
-	local gh_pr_dir="" gh_pr_title="" gh_pr_head=""
-	_prepare_pr_review_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head || return 1
+	local gh_pr_dir="" gh_pr_title="" gh_pr_head="" gh_pr_url=""
+	_prepare_pr_review_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head gh_pr_url || return 1
 
 	local gh_pr_agent_model
 	gh_pr_agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
@@ -524,6 +526,7 @@ _gh_pr_review() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$gh_pr_agent_model" < <(
 				GH_PR_NUMBER="$gh_pr_number" \
 					GH_PR_TITLE="$gh_pr_title" \
+					GH_PR_URL="$gh_pr_url" \
 					GH_PR_BODY_FILE="$gh_pr_dir/pr_body.md" \
 					GH_PR_DIFF_FILE="$gh_pr_dir/pr_diff.patch" \
 					GH_PR_DIFF_STAT_FILE="$gh_pr_dir/pr_diff_stat.txt" \
@@ -640,8 +643,8 @@ _gh_pr_explain() {
 		return 1
 	fi
 
-	local gh_pr_dir="" gh_pr_title="" gh_pr_head=""
-	_prepare_pr_explain_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head || return 1
+	local gh_pr_dir="" gh_pr_title="" gh_pr_head="" gh_pr_url=""
+	_prepare_pr_explain_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head gh_pr_url || return 1
 
 	local gh_pr_agent_model
 	gh_pr_agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
@@ -654,6 +657,7 @@ _gh_pr_explain() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$gh_pr_agent_model" < <(
 				GH_PR_NUMBER="$gh_pr_number" \
 					GH_PR_TITLE="$gh_pr_title" \
+					GH_PR_URL="$gh_pr_url" \
 					GH_PR_BODY_FILE="$gh_pr_dir/pr_body.md" \
 					GH_PR_DIFF_FILE="$gh_pr_dir/pr_diff.patch" \
 					GH_PR_DIFF_STAT_FILE="$gh_pr_dir/pr_diff_stat.txt" \
@@ -756,8 +760,8 @@ _gh_pr_chat() {
 		return 1
 	fi
 
-	local gh_pr_dir="" gh_pr_title="" gh_pr_head=""
-	_prepare_pr_chat_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head || return 1
+	local gh_pr_dir="" gh_pr_title="" gh_pr_head="" gh_pr_url=""
+	_prepare_pr_chat_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_head gh_pr_url || return 1
 
 	if [[ -z "$gh_pr_head" ]]; then
 		gum log --level error "Could not determine head branch for pull request #$gh_pr_number"
@@ -782,6 +786,7 @@ _gh_pr_chat() {
 		gh_pr_preamble=$(
 			GH_PR_NUMBER="$gh_pr_number" \
 				GH_PR_TITLE="$gh_pr_title" \
+				GH_PR_URL="$gh_pr_url" \
 				GH_PR_FOCUS="$gh_pr_focus" \
 				GH_SESSION_DIR="$gh_pr_dir" \
 				GH_PR_HEAD="$gh_pr_head" \
@@ -801,15 +806,16 @@ _parse_pr_comment_args() { _parse_pr_args "comment" "$@"; }
 # Context for _gh_pr_comment: fetches PR body and comments, and reads optional
 # stdin into pr_context.md. Uses a temporary directory.
 #
-# Usage: _prepare_pr_comment_context pr_number gh_pr_dir_ref title_ref
+# Usage: _prepare_pr_comment_context pr_number gh_pr_dir_ref title_ref url_ref
 _prepare_pr_comment_context() {
 	local _ctx_num="$1"
 	local -n _ctx_dir="$2"
 	local -n _ctx_title="$3"
+	local -n _ctx_url="$4"
 
 	local _ctx_meta
 	_ctx_meta=$(gum spin --title "Fetching GitHub pull request #$_ctx_num metadata..." -- \
-		gh pr view "$_ctx_num" --json title,body,comments || true)
+		gh pr view "$_ctx_num" --json title,body,comments,url || true)
 	if [[ -z "$_ctx_meta" ]]; then
 		gum log --level error "Failed to fetch pull request #$_ctx_num"
 		return 1
@@ -901,8 +907,8 @@ _gh_pr_comment() {
 		return 1
 	fi
 
-	local gh_pr_dir="" gh_pr_title=""
-	_prepare_pr_comment_context "$gh_pr_number" gh_pr_dir gh_pr_title || return 1
+	local gh_pr_dir="" gh_pr_title="" gh_pr_url=""
+	_prepare_pr_comment_context "$gh_pr_number" gh_pr_dir gh_pr_title gh_pr_url || return 1
 
 	local gh_pr_agent_model
 	gh_pr_agent_model=$(gh config get ai.pr.model 2>/dev/null || true)
@@ -915,6 +921,7 @@ _gh_pr_comment() {
 			"$_gh_ai_source_dir/scripts/gh_cmd.sh" ask "$gh_pr_agent_model" < <(
 				GH_PR_NUMBER="$gh_pr_number" \
 					GH_PR_TITLE="$gh_pr_title" \
+					GH_PR_URL="$gh_pr_url" \
 					GH_PR_BODY_FILE="$gh_pr_dir/pr_body.md" \
 					GH_PR_COMMENTS_FILE="$gh_pr_dir/pr_comments.md" \
 					GH_PR_DESCRIPTION="$gh_pr_description" \

--- a/scripts/gh_pr_meta.jq
+++ b/scripts/gh_pr_meta.jq
@@ -2,4 +2,5 @@
 "_ctx_head=" + ((.headRefName // "") | @sh),
 "_ctx_body=" + ((.body // "") | @sh),
 "_ctx_commits=" + (([(.commits // [])[] | "- " + .messageHeadline] | join("\n")) | @sh),
-"_ctx_comments=" + (([(.comments // [])[].body] | join("\n---\n")) | @sh)
+"_ctx_comments=" + (([(.comments // [])[].body] | join("\n---\n")) | @sh),
+"_ctx_url=" + ((.url // "") | @sh)

--- a/templates/gh_issue_chat.tmpl
+++ b/templates/gh_issue_chat.tmpl
@@ -3,6 +3,7 @@ You are helping with a GitHub issue. Here is the context:
 <issue>
 Number: ${GH_ISSUE_NUMBER}
 Title: ${GH_ISSUE_TITLE}
+URL: ${GH_ISSUE_URL}
 Labels: ${GH_ISSUE_LABELS}
 </issue>
 

--- a/templates/gh_issue_comment.tmpl
+++ b/templates/gh_issue_comment.tmpl
@@ -3,6 +3,7 @@ Write a comment for the following GitHub issue based on the requested instructio
 <issue>
 Number: ${GH_ISSUE_NUMBER}
 Title: ${GH_ISSUE_TITLE}
+URL: ${GH_ISSUE_URL}
 Body: ${GH_ISSUE_BODY}
 Labels: ${GH_ISSUE_LABELS}
 </issue>

--- a/templates/gh_issue_edit.tmpl
+++ b/templates/gh_issue_edit.tmpl
@@ -3,6 +3,7 @@ Edit the following GitHub issue based on the requested changes.
 <issue>
 Number: ${GH_ISSUE_NUMBER}
 Title: ${GH_ISSUE_TITLE}
+URL: ${GH_ISSUE_URL}
 Body: ${GH_ISSUE_BODY}
 Labels: ${GH_ISSUE_LABELS}
 </issue>

--- a/templates/gh_issue_plan.tmpl
+++ b/templates/gh_issue_plan.tmpl
@@ -3,6 +3,7 @@ Create an implementation plan for the following GitHub issue.
 <issue>
 Number: ${GH_ISSUE_NUMBER}
 Title: ${GH_ISSUE_TITLE}
+URL: ${GH_ISSUE_URL}
 Body: ${GH_ISSUE_BODY}
 Labels: ${GH_ISSUE_LABELS}
 </issue>

--- a/templates/gh_pr_chat.tmpl
+++ b/templates/gh_pr_chat.tmpl
@@ -3,6 +3,7 @@ You are helping with a GitHub pull request. Here is the context:
 <pull_request>
 Number: ${GH_PR_NUMBER}
 Title: ${GH_PR_TITLE}
+URL: ${GH_PR_URL}
 Head: ${GH_PR_HEAD}
 Worktree branch: ${GH_WT_BRANCH}
 </pull_request>

--- a/templates/gh_pr_comment.tmpl
+++ b/templates/gh_pr_comment.tmpl
@@ -4,6 +4,7 @@ Do not write a code review — produce a natural, targeted comment for the PR co
 <pull_request>
 Number: ${GH_PR_NUMBER}
 Title: ${GH_PR_TITLE}
+URL: ${GH_PR_URL}
 Body: ${GH_PR_BODY}
 </pull_request>
 

--- a/templates/gh_pr_edit.tmpl
+++ b/templates/gh_pr_edit.tmpl
@@ -3,6 +3,7 @@ Edit the following GitHub pull request based on the requested changes.
 <pull_request>
 Number: ${GH_PR_NUMBER}
 Title: ${GH_PR_TITLE}
+URL: ${GH_PR_URL}
 Body: ${GH_PR_BODY}
 </pull_request>
 

--- a/templates/gh_pr_explain.tmpl
+++ b/templates/gh_pr_explain.tmpl
@@ -3,6 +3,7 @@ Explain what this pull request does in clear, accessible language.
 <pull_request>
 Number: ${GH_PR_NUMBER}
 Title: ${GH_PR_TITLE}
+URL: ${GH_PR_URL}
 Branch: ${GH_PR_HEAD}
 </pull_request>
 

--- a/templates/gh_pr_review.tmpl
+++ b/templates/gh_pr_review.tmpl
@@ -3,6 +3,7 @@ Review the pull request diff below. Assess the overall approach and design first
 <pull_request>
 Number: ${GH_PR_NUMBER}
 Title: ${GH_PR_TITLE}
+URL: ${GH_PR_URL}
 Body: ${GH_PR_BODY}
 Branch: ${GH_PR_HEAD}
 </pull_request>

--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -149,7 +149,7 @@ setup() {
 _setup_chat_mocks() {
 	gh() {
 		case "$1 $2" in
-		"issue view") printf '{"title":"Test Issue","body":"Issue body","labels":[],"comments":[]}' ;;
+		"issue view") printf '{"title":"Test Issue","body":"Issue body","labels":[],"comments":[],"url":"https://github.com/owner/repo/issues/42"}' ;;
 		"config get") ;;
 		esac
 	}

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -150,7 +150,7 @@ _setup_chat_mocks() {
 	gh() {
 		case "$1 $2" in
 		"pr diff") echo "diff --git a/file.txt b/file.txt" ;;
-		"pr view") printf '{"title":"Test PR Title","body":"PR body","headRefName":"feature-branch","commits":[{"messageHeadline":"Test commit"}]}' ;;
+		"pr view") printf '{"title":"Test PR Title","body":"PR body","headRefName":"feature-branch","commits":[{"messageHeadline":"Test commit"}],"url":"https://github.com/owner/repo/pull/42"}' ;;
 		"config get") ;;
 		esac
 	}


### PR DESCRIPTION
## Summary

- Adds `GH_PR_URL` and `GH_ISSUE_URL` to all PR and issue templates for better traceability
- Extracts the `url` field from GitHub API responses via the jq meta scripts and threads it through each prepare context function and render call site

## Changes

- `scripts/gh_pr_meta.jq` / `scripts/gh_issue_meta.jq` — extract `_ctx_url` from API response
- `_prepare_pr_diff_context` / `_prepare_pr_comment_context` — add `url_ref` nameref (6th / 4th param); add `url` to `gh pr view --json` fields
- `_prepare_issue_context` — add `url_ref` nameref (6th param); add `url` to `gh issue view --json` fields
- All render call sites (5 PR + 4 issue) — pass `GH_PR_URL` / `GH_ISSUE_URL` env var
- Templates (9 files) — add `URL:` line to `<pull_request>` / `<issue>` blocks

**Skipped:** `gh_pr_create.tmpl` and `gh_issue_create.tmpl` — artifact does not exist yet at create time.

Closes #55