### PR TITLE
fix: update test mocks to include url field

### DIFF
--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -149,7 +149,7 @@ setup() {
 _setup_chat_mocks() {
 	gh() {
 		case "$1 $2" in
-		"issue view") printf '{"title":"Test Issue","body":"Issue body","labels":[],"comments":[]}' ;;
+		"issue view") printf '{"title":"Test Issue","body":"Issue body","labels":[],"comments":[],"url":"https://github.com/owner/repo/issues/42"}' ;;
 		"config get") ;;
 		esac
 	}

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -150,7 +150,7 @@ _setup_chat_mocks() {
 	gh() {
 		case "$1 $2" in
 		"pr diff") echo "diff --git a/file.txt b/file.txt" ;;
-		"pr view") printf '{"title":"Test PR Title","body":"PR body","headRefName":"feature-branch","commits":[{"messageHeadline":"Test commit"}]}' ;;
+		"pr view") printf '{"title":"Test PR Title","body":"PR body","headRefName":"feature-branch","commits":[{"messageHeadline":"Test commit"}],"url":"https://github.com/owner/repo/pull/42"}' ;;
 		"config get") ;;
 		esac
 	}


### PR DESCRIPTION
## Summary

- Add `"url"` to the `gh issue view` mock response in `tests/gh_issue_chat.bats`
- Add `"url"` to the `gh pr view` mock response in `tests/gh_pr_chat.bats`

The `_prepare_issue_context` and `_prepare_pr_diff_context` functions now request the `url` field via `--json` (added in feat: include PR and issue URLs in templates). The test stubs didn't include `url`, causing a mismatch between mock output and what the real `gh` CLI returns.

## Test plan

- [x] `bats tests/gh_issue_chat.bats` — all tests pass
- [x] `bats tests/gh_pr_chat.bats` — all tests pass
- [ ] `bats tests/gh_run_chat.bats` — all tests pass (no changes needed, mock already included `url`)