### PR TITLE
fix(tests): export _gum and _has_gum in BATS setup functions

### DIFF
--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -33,7 +33,8 @@ setup() {
 		declare -f _extract_issue_number _parse_chat_args _parse_issue_chat_args _validate_chat_passthrough _show_issue_chat_help _gh_issue_chat \
 			_cmd_chat _cmd_render _split_on_separator _get_agent _git_repo_path _resolve_chat_session \
 			_prepare_issue_chat_context _prepare_issue_context _resolve_context_dir _create_context_dir _save_context_file \
-			_gh_session_base_dir
+			_gh_session_base_dir \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_issue_comment.bats
+++ b/tests/gh_issue_comment.bats
@@ -22,7 +22,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_issue.sh
 		source "$REPO_ROOT/scripts/gh_issue.sh"
-		declare -f _extract_issue_number _parse_issue_args _parse_issue_comment_args _show_issue_comment_help _gh_issue_comment _split_on_separator
+		declare -f _extract_issue_number _parse_issue_args _parse_issue_comment_args _show_issue_comment_help _gh_issue_comment _split_on_separator \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_issue_create.bats
+++ b/tests/gh_issue_create.bats
@@ -22,7 +22,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_issue.sh
 		source "$REPO_ROOT/scripts/gh_issue.sh"
-		declare -f _parse_issue_create_args _show_issue_create_help _gh_issue_create _split_on_separator
+		declare -f _parse_issue_create_args _show_issue_create_help _gh_issue_create _split_on_separator \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_issue_edit.bats
+++ b/tests/gh_issue_edit.bats
@@ -22,7 +22,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_issue.sh
 		source "$REPO_ROOT/scripts/gh_issue.sh"
-		declare -f _extract_issue_number _parse_issue_args _parse_issue_edit_args _show_issue_edit_help _gh_issue_edit _split_on_separator
+		declare -f _extract_issue_number _parse_issue_args _parse_issue_edit_args _show_issue_edit_help _gh_issue_edit _split_on_separator \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_issue_plan.bats
+++ b/tests/gh_issue_plan.bats
@@ -23,7 +23,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _extract_issue_number _parse_issue_args _parse_issue_plan_args _show_issue_plan_help _gh_issue_plan \
 			_prepare_issue_context _prepare_issue_plan_context _resolve_context_dir _create_context_dir _save_context_file \
-			_cmd_render _cmd_ask _get_agent _parse_title _parse_body
+			_cmd_render _cmd_ask _get_agent _parse_title _parse_body \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -33,7 +33,8 @@ setup() {
 		declare -f _extract_pr_number _parse_chat_args _parse_pr_chat_args _validate_chat_passthrough _show_pr_chat_help _gh_pr_chat _detect_pr_number \
 			_cmd_chat _cmd_render _split_on_separator _get_agent _git_repo_path _resolve_chat_session \
 			_prepare_pr_chat_context _prepare_pr_diff_context _resolve_context_dir _create_context_dir _save_context_file \
-			_gh_session_base_dir
+			_gh_session_base_dir \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_pr_comment.bats
+++ b/tests/gh_pr_comment.bats
@@ -25,7 +25,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_pr.sh"
 		declare -f _extract_pr_number _parse_pr_args _parse_pr_comment_args _show_pr_comment_help _gh_pr_comment \
 			_detect_pr_number _split_on_separator _create_context_dir _save_context_file \
-			_prepare_pr_comment_context
+			_prepare_pr_comment_context \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_pr_create.bats
+++ b/tests/gh_pr_create.bats
@@ -22,7 +22,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_pr.sh
 		source "$REPO_ROOT/scripts/gh_pr.sh"
-		declare -f _parse_pr_create_args _show_pr_create_help _gh_pr_create _split_on_separator _git_branch_diff
+		declare -f _parse_pr_create_args _show_pr_create_help _gh_pr_create _split_on_separator _git_branch_diff \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_pr_edit.bats
+++ b/tests/gh_pr_edit.bats
@@ -22,7 +22,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_pr.sh
 		source "$REPO_ROOT/scripts/gh_pr.sh"
-		declare -f _extract_pr_number _detect_pr_number _parse_pr_args _parse_pr_edit_args _show_pr_edit_help _gh_pr_edit _split_on_separator
+		declare -f _extract_pr_number _detect_pr_number _parse_pr_args _parse_pr_edit_args _show_pr_edit_help _gh_pr_edit _split_on_separator \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_pr_explain.bats
+++ b/tests/gh_pr_explain.bats
@@ -24,7 +24,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_pr.sh"
 		declare -f _extract_pr_number _parse_pr_args _detect_pr_number _parse_pr_explain_args _show_pr_explain_help _gh_pr_explain \
 			_prepare_pr_diff_context _prepare_pr_explain_context _resolve_context_dir _create_context_dir _save_context_file \
-			_split_on_separator _cmd_render _cmd_ask _get_agent
+			_split_on_separator _cmd_render _cmd_ask _get_agent \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_pr_review.bats
+++ b/tests/gh_pr_review.bats
@@ -23,7 +23,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_pr.sh
 		source "$REPO_ROOT/scripts/gh_pr.sh"
-		declare -f _extract_pr_number _detect_pr_number _parse_pr_args _parse_pr_review_args _show_pr_review_help _gh_pr_review _split_on_separator
+		declare -f _extract_pr_number _detect_pr_number _parse_pr_args _parse_pr_review_args _show_pr_review_help _gh_pr_review _split_on_separator \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_run_chat.bats
+++ b/tests/gh_run_chat.bats
@@ -33,7 +33,8 @@ setup() {
 		declare -f _parse_chat_args _parse_run_chat_args _validate_chat_passthrough _show_run_chat_help _gh_run_chat \
 			_cmd_chat _cmd_render _split_on_separator _get_agent _git_repo_path _resolve_chat_session \
 			_prepare_run_chat_context _prepare_run_context _resolve_context_dir _create_context_dir _save_context_file \
-			_parse_run_args _gh_session_base_dir
+			_parse_run_args _gh_session_base_dir \
+			_gum _has_gum
 	)"
 }
 

--- a/tests/gh_run_explain.bats
+++ b/tests/gh_run_explain.bats
@@ -23,7 +23,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _parse_run_args _parse_run_explain_args _show_run_explain_help _gh_run_explain \
 			_prepare_run_context _prepare_run_explain_context _resolve_context_dir _create_context_dir _save_context_file \
-			_cmd_render _cmd_ask _get_agent
+			_cmd_render _cmd_ask _get_agent \
+			_gum _has_gum
 	)"
 }
 


### PR DESCRIPTION
## Summary

- Adds `_gum` and `_has_gum` to the `declare -f` export list in the `setup()` function of 13 BATS test files
- These two helpers from `scripts/gh_cmd.sh` were missing from the function exports, so any function calling `_gum log` or `_gum spin` inside a test had no output and/or exited non-zero
- Fixes all 56 failing tests from workflow run [#23223576720](https://github.com/gh-extensions/gh-ai/actions/runs/23223576720) (`chore(main): release 0.19.0`)

## Affected files

`tests/gh_issue_chat.bats`, `tests/gh_issue_comment.bats`, `tests/gh_issue_create.bats`, `tests/gh_issue_edit.bats`, `tests/gh_issue_plan.bats`, `tests/gh_pr_chat.bats`, `tests/gh_pr_comment.bats`, `tests/gh_pr_create.bats`, `tests/gh_pr_edit.bats`, `tests/gh_pr_explain.bats`, `tests/gh_pr_review.bats`, `tests/gh_run_chat.bats`, `tests/gh_run_explain.bats`

## Test plan

- [x] Run `nix develop --command bats tests/` — all 287 tests should pass
- [x] Verify previously-failing tests now pass: 66–68, 71, 74, 76–77, 88, 97–98, 109, 117–120, 122, 150–152, 155, 157, 160, 163–166, 178, 181, 187–189, 201–202, 204, 216, 219, 222–224, 227–228, 241–242, 245, 255–258, 261, 264, 266–267, 271–274