### PR TITLE
feat: add slash command skills for issue workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,46 @@ gh ai issue chat 42 -d "focus on the auth module"
 gh ai issue chat 42 -n                # start a new session
 ```
 
+### Slash Commands
+
+Slash command equivalents for issue workflows, usable directly inside a Claude
+Code session. Each command fetches live issue data, generates a draft, and waits
+for confirmation before executing.
+
+```
+/gh:issue:comment <issue-number> [what to say]
+/gh:issue:edit    <issue-number> [what to change]
+/gh:issue:plan    <issue-number> [focus area]
+```
+
+All three commands follow a **draft → iterate → confirm → execute** workflow:
+generate a draft, show it to the user, accept revision requests, and only run
+the `gh` CLI command once the user confirms.
+
+**Post a comment on an issue:**
+
+```
+/gh:issue:comment 42 ask for clarification on the acceptance criteria
+/gh:issue:comment 42 summarize the discussion so far
+```
+
+**Edit an issue title and body:**
+
+```
+/gh:issue:edit 42 add a definition of done section
+/gh:issue:edit 42 rewrite the description as a bug report
+```
+
+**Generate an implementation plan and post it as a comment:**
+
+```
+/gh:issue:plan 42
+/gh:issue:plan 42 focus on the auth module
+```
+
+> These are Claude Code skill equivalents to `gh ai issue comment`,
+> `gh ai issue edit`, and `gh ai issue plan`.
+
 ### Run
 
 Analyzes a GitHub Actions workflow run and explains what happened.

--- a/templates/gh_issue_comment.md
+++ b/templates/gh_issue_comment.md
@@ -1,0 +1,58 @@
+---
+name: gh:issue:comment
+description: >
+  Drafts a GitHub issue comment and posts it after user confirmation. Use when
+  the user wants to write, draft, or post a comment on a GitHub issue, or needs
+  help wording a reply. Trigger when the user says "write a comment on issue #N",
+  "draft a response to this issue", "add a comment saying...", "reply to this
+  issue", or invokes the command directly while working on an issue.
+argument-hint: <issue-number> [what to say]
+disable-model-invocation: true
+allowed-tools: Bash(gh *), Write
+---
+
+Draft a GitHub issue comment, then post it after the user confirms.
+
+## Issue context
+
+!`gh issue view $ARGUMENTS[0] --json number,title,url,body,labels,comments 2>/dev/null | jq -r -f templates/gh_issue_view.jq || echo "Unable to fetch issue. Check the issue number and gh auth status."`
+
+## Additional context
+
+!`cat ".github/sessions/issue-$ARGUMENTS[0]/issue_context.md" 2>/dev/null || true`
+
+## Request
+
+!`echo "$ARGUMENTS" | cut -d' ' -f2-`
+
+(If the request is empty, infer the most helpful comment from the issue context.)
+
+## Workflow
+
+1. Write the comment draft based on the issue context and the request above.
+2. Show the draft to the user clearly marked as a draft.
+3. Ask the user: "Post this comment, or tell me what to change?"
+4. If the user requests changes, revise and repeat from step 2.
+5. When the user confirms, write the final comment to `.github/sessions/issue-$ARGUMENTS[0]/issue_comment_draft.md` and run:
+   `gh issue comment $ARGUMENTS[0] --body-file .github/sessions/issue-$ARGUMENTS[0]/issue_comment_draft.md`
+6. Confirm the action was successful with the URL of the posted comment.
+
+## Rules
+
+- Keep the tone concise, natural, and appropriate for a GitHub discussion.
+- Prefer concrete references to issue details when possible.
+- If information required to fulfill the request is missing, say so rather than guessing.
+
+## Draft format
+
+ALWAYS present the draft clearly so the user can read it before confirming:
+
+---
+
+**Draft comment for issue #N:**
+
+{comment body in GitHub-flavored Markdown}
+
+---
+
+_Post this comment, or tell me what to change._

--- a/templates/gh_issue_edit.md
+++ b/templates/gh_issue_edit.md
@@ -1,0 +1,62 @@
+---
+name: gh:issue:edit
+description: >
+  Edits a GitHub issue title and body according to requested changes, then
+  applies the edit after user confirmation. Use when the user wants to update,
+  modify, improve, or rewrite an issue — for example "edit issue #N to add
+  acceptance criteria", "update the issue body", "rewrite the description",
+  "fix the issue title", "add a definition of done", or "improve this issue".
+argument-hint: <issue-number> [what to change]
+disable-model-invocation: true
+allowed-tools: Bash(gh *), Write
+---
+
+Edit a GitHub issue according to the requested changes, then apply it after confirmation.
+
+## Issue context
+
+!`gh issue view $ARGUMENTS[0] --json number,title,url,body,labels,comments 2>/dev/null | jq -r -f templates/gh_issue_view.jq || echo "Unable to fetch issue. Check the issue number and gh auth status."`
+
+## Additional context
+
+!`cat ".github/sessions/issue-$ARGUMENTS[0]/issue_context.md" 2>/dev/null || true`
+
+## Requested changes
+
+!`echo "$ARGUMENTS" | cut -d' ' -f2-`
+
+(If no changes are specified, ask the user what they want to change.)
+
+## Workflow
+
+1. Apply the requested changes to produce an updated title and body.
+2. Show the full updated issue to the user clearly marked as a draft.
+3. Ask the user: "Apply this edit, or tell me what to change?"
+4. If the user requests changes, revise and repeat from step 2.
+5. When the user confirms:
+   - Extract the title from the draft (the first `# ...` line, without the `# ` prefix)
+   - Write ONLY the body (everything after the title line) to `.github/sessions/issue-$ARGUMENTS[0]/issue_body_draft.md` — do NOT include the `# Title` line in the file
+   - Run: `gh issue edit $ARGUMENTS[0] --title "<extracted title>" --body-file .github/sessions/issue-$ARGUMENTS[0]/issue_body_draft.md`
+6. Confirm success with the issue URL.
+
+## Rules
+
+- Apply only the requested changes.
+- Preserve existing wording and structure unless the request explicitly requires modification.
+- If the requested change is ambiguous, identify what clarification is needed.
+
+## Draft format
+
+ALWAYS present the draft clearly so the user can read it before confirming:
+
+---
+
+**Draft edit for issue #N:**
+
+# {title under 72 chars}
+
+{updated issue body in GitHub-flavored Markdown}
+
+---
+
+_Apply this edit, or tell me what to change._

--- a/templates/gh_issue_plan.md
+++ b/templates/gh_issue_plan.md
@@ -1,0 +1,81 @@
+---
+name: gh:issue:plan
+description: >
+  Drafts an implementation plan for a GitHub issue and posts it as a comment
+  after user confirmation. The plan is a proposal for discussion, not an
+  execution trigger. Use when the user wants to plan how to implement or solve
+  an issue — "plan issue #N", "create an implementation plan", "what steps do I
+  need to implement #N?", "break down this issue into tasks", or asks for a
+  TODO list or task checklist for an issue.
+argument-hint: <issue-number> [focus area]
+disable-model-invocation: true
+allowed-tools: Bash(gh *), Write
+---
+
+Draft an implementation plan for a GitHub issue, then post it as a comment after confirmation.
+The plan is a proposal for discussion — this command does not execute the plan.
+
+## Issue context
+
+!`gh issue view $ARGUMENTS[0] --json number,title,url,body,labels,comments 2>/dev/null | jq -r -f templates/gh_issue_view.jq || echo "Unable to fetch issue. Check the issue number and gh auth status."`
+
+## Additional context
+
+!`cat ".github/sessions/issue-$ARGUMENTS[0]/issue_context.md" 2>/dev/null || true`
+
+## Focus
+
+!`echo "$ARGUMENTS" | cut -d' ' -f2-`
+
+(If the focus is empty, plan the full implementation.)
+
+## Workflow
+
+1. Think step by step: understand requirements, identify affected components, break into tasks.
+2. Write the implementation plan draft.
+3. Show the draft to the user clearly marked as a draft.
+4. Ask the user: "Post this plan as a comment, or tell me what to change?"
+5. If the user requests changes, revise and repeat from step 3.
+6. When the user confirms, append `<!-- gh-ai:issue-plan issue=N -->` (with the actual issue number)
+   as the last line of the plan body and write it to `.github/sessions/issue-$ARGUMENTS[0]/issue_plan_draft.md`.
+7. Resolve the repository name: `gh repo view --json nameWithOwner --jq .nameWithOwner`
+8. Check if a plan comment already exists on the issue (use `--paginate` to search all comments).
+   The marker to search for is `<!-- gh-ai:issue-plan issue=N -->` with the actual issue number.
+   `gh api repos/<owner>/<repo>/issues/<N>/comments --paginate | jq -s '[.[][] | select(.body | contains("<!-- gh-ai:issue-plan issue=<N> -->"))] | last | .id'`
+   - If a comment ID is returned: update it:
+     `gh api repos/<owner>/<repo>/issues/comments/<ID> -X PATCH -F body=@.github/sessions/issue-$ARGUMENTS[0]/issue_plan_draft.md`
+   - If no comment is found: create a new one:
+     `gh issue comment $ARGUMENTS[0] --body-file .github/sessions/issue-$ARGUMENTS[0]/issue_plan_draft.md`
+9. Confirm success with the URL of the posted or updated comment.
+
+## Rules
+
+- This is a draft plan for discussion, not an execution trigger. Do not attempt to implement the plan.
+- Focus on concrete engineering tasks rather than vague descriptions.
+- Use sequential step IDs (T001, T002...) for implementation steps.
+- If the issue lacks sufficient detail, highlight the missing information.
+- If a focus area is provided, scope the plan to that area only.
+
+## Draft format
+
+ALWAYS present the draft clearly so the user can read it before confirming:
+
+---
+
+**Draft implementation plan for issue #N:**
+
+## Summary
+{1-2 sentence description of the proposed approach}
+
+## Plan
+- T001 — {step}
+- T002 — {step}
+
+## Open Questions
+- {anything that needs clarification before implementation; omit this section if there are none}
+
+<!-- gh-ai:issue-plan issue={N} -->
+
+---
+
+_Post this plan as a comment, or tell me what to change._

--- a/templates/gh_issue_view.jq
+++ b/templates/gh_issue_view.jq
@@ -1,0 +1,5 @@
+"Issue #\(.number): \(.title)"
++ "\nURL: \(.url)"
++ "\nLabels: \(.labels // [] | map(.name) | join(", ") | if . == "" then "(none)" else . end)"
++ "\n\nBody:\n\(.body // "(no body)")"
++ "\n\nComments:\n\(.comments | if length == 0 then "(no comments)" else map("@\(.author.login // "ghost"): \(.body)") | join("\n\n---\n\n") end)"


### PR DESCRIPTION
## Summary

- Add three Claude Code slash command skills (`/gh:issue:comment`, `/gh:issue:edit`, `/gh:issue:plan`) as equivalents to the existing `gh ai issue` CLI commands
- Each skill fetches live issue data, generates a draft, iterates with the user, and executes only after confirmation
- Add shared `skills/gh_issue_view.jq` filter for consistent issue data formatting
- Document the new slash commands in the README

Closes #74

## Test plan

- [x] Verify `/gh:issue:comment <N> <msg>` fetches issue, shows draft, posts after confirm
- [x] Verify `/gh:issue:edit <N> <changes>` fetches issue, shows draft, applies edit after confirm
- [x] Verify `/gh:issue:plan <N>` fetches issue, generates plan draft, posts/updates comment after confirm
- [x] Verify plan upsert logic (creates new comment or updates existing `<!-- gh-ai:issue-plan -->` comment)
- [x] Confirm `skills/gh_issue_view.jq` is correctly resolved from all three skill files