### PR TITLE
Move claude agent args before subcommand to eliminate -- separator

### DIFF
--- a/.github/claude/plans/86-claude-args-before-subcommand.md
+++ b/.github/claude/plans/86-claude-args-before-subcommand.md
@@ -1,0 +1,171 @@
+<!-- gh-claude:issue-plan issue=86 -->
+
+# Move claude agent args before subcommand — Execution Plan
+
+**Issue:** [#86](https://github.com/gh-extensions/gh-claude/issues/86) — Move claude agent args before subcommand to eliminate -- separator
+**Branch:** `86/claude-args-before-subcommand`
+**Type:** Refactor
+**Estimate:** Small (1-2 days)
+**Risk:** Medium — touches argument parsing in every command path; breaking change to CLI interface
+**Created:** 2026-03-19
+
+---
+
+## Goal
+
+Eliminate the `--` separator for claude agent args by collecting them before the subcommand keyword (e.g., `gh claude --model sonnet pr chat 42` instead of `gh claude pr chat 42 -- --model sonnet`). The `--` separator remains only for `gh` CLI passthrough args in create/edit/comment/review commands. No backward compatibility — the old `--` syntax for agent args stops working.
+
+## Approach
+
+Add an arg collection loop to `main()` in `gh-claude` that scans arguments until it hits a recognized subcommand keyword (`pr`, `issue`, `run`). Everything before the keyword goes into a script-scoped `_GH_CLAUDE_ARGS=()` array. The subcommand dispatchers (`_gh_pr`, `_gh_issue`, `_gh_run`) don't need signature changes since `_GH_CLAUDE_ARGS` is visible as a script-level variable. Chat commands forward the full array to `_cmd_chat` (called in-process). Ask-mode commands extract `--model` from the array to override config. Chat commands stop using `_split_on_separator` and `_extract_chat_passthrough` entirely — those functions remain only for create/edit/comment/review `gh` passthrough.
+
+## Affected Areas
+
+- `gh-claude:L82-L109` — `main()` arg collection loop
+- `scripts/gh_cmd.sh:L58-L72` — `_cmd_ask` model override
+- `scripts/gh_cmd.sh:L105-L125` — `_cmd_chat` forwarding `_GH_CLAUDE_ARGS`
+- `scripts/gh_cmd.sh:L415-L453` — `_extract_chat_passthrough` (remove usage from chat path)
+- `scripts/gh_pr.sh:L798-L860` — `_gh_pr_chat` simplified
+- `scripts/gh_pr.sh:L758-L789` — `_show_pr_chat_help` updated
+- `scripts/gh_pr.sh:L1012-L1044` — `_show_pr_help` updated
+- `scripts/gh_issue.sh:L738-L790` — `_gh_issue_chat` simplified
+- `scripts/gh_issue.sh:L699-L729` — `_show_issue_chat_help` updated
+- `scripts/gh_issue.sh:L796-L827` — `_show_issue_help` updated
+- `scripts/gh_run.sh:L241-L296` — `_gh_run_chat` simplified
+- `scripts/gh_run.sh:L202-L232` — `_show_run_chat_help` updated
+- `scripts/gh_run.sh:L298-L322` — `_show_run_help` updated
+- `tests/gh_pr_chat.bats` — update passthrough tests
+- `tests/gh_issue_chat.bats` — update passthrough tests
+- `tests/gh_run_chat.bats` — update passthrough tests
+- `tests/gh_cmd.bats` — new tests for arg collection and `_extract_claude_arg`
+
+## Tasks
+
+### Task 1: Collect claude args in `main()` — S — [x] Complete
+
+**What:** Replace the `cmd="${1:-}"; shift` pattern in `gh-claude:main()` with a loop that collects all arguments before the first recognized subcommand keyword (`pr`, `issue`, `run`) into a script-scoped `_GH_CLAUDE_ARGS=()` array. Handle `--help`/`--version` as early exits during scanning. The keyword and everything after dispatch normally.
+
+**Files:**
+
+- Modify: `gh-claude`
+
+**Test strategy:** Test in Task 5. Key scenarios: no claude args (just subcommand), single flag (`--model sonnet`), multiple flags, `--help` before subcommand, `--version`, unknown arg before subcommand, no subcommand at all.
+
+**Acceptance criteria:**
+
+- [ ] `gh claude --model sonnet pr chat 42` collects `--model sonnet` into `_GH_CLAUDE_ARGS` and dispatches `pr chat 42`
+- [ ] `gh claude pr chat 42` works with empty `_GH_CLAUDE_ARGS`
+- [ ] `gh claude --help` and `gh claude --version` still work
+- [ ] `gh claude` with no args shows help
+
+**Commit message:** `refactor(main): collect claude args before subcommand keyword`
+
+---
+
+### Task 2: Forward `_GH_CLAUDE_ARGS` in `_cmd_chat` and extract model for ask-mode — M — [x] Complete
+
+**What:** In `_cmd_chat`, append `"${_GH_CLAUDE_ARGS[@]}"` to the `claude` invocation (after session args). Add a helper `_extract_claude_arg` that reads a named flag's value from `_GH_CLAUDE_ARGS` (e.g., `_extract_claude_arg --model` returns the model value). In each ask-mode caller, use `_extract_claude_arg --model` to override `_gh_config_claude_model` when `--model` was passed globally. The `_cmd_ask` subprocess receives the model via its existing positional parameter, so no subprocess interface changes.
+
+**Files:**
+
+- Modify: `scripts/gh_cmd.sh` — add `_extract_claude_arg`, update `_cmd_chat`
+- Modify: `scripts/gh_pr.sh` — all ask-mode callers (`_gh_pr_create`, `_gh_pr_edit`, `_gh_pr_review`, `_gh_pr_explain`, `_gh_pr_comment`) use `_extract_claude_arg --model` to override model
+- Modify: `scripts/gh_issue.sh` — ask-mode callers (`_gh_issue_create`, `_gh_issue_edit`, `_gh_issue_comment`, `_gh_issue_plan`) use override
+- Modify: `scripts/gh_run.sh` — ask-mode caller (`_gh_run_explain`) uses override
+
+**Test strategy:** Test `_extract_claude_arg` in `gh_cmd.bats`. Verify model override works when `_GH_CLAUDE_ARGS` contains `--model sonnet`. Verify `_cmd_chat` forwards all `_GH_CLAUDE_ARGS` to claude.
+
+**Acceptance criteria:**
+
+- [ ] `_extract_claude_arg --model` returns value when `_GH_CLAUDE_ARGS=(--model sonnet)`
+- [ ] `_extract_claude_arg --model` returns empty when `_GH_CLAUDE_ARGS` has no `--model`
+- [ ] `_cmd_chat` forwards `_GH_CLAUDE_ARGS` entries to the claude binary
+- [ ] Ask-mode commands use `--model` from `_GH_CLAUDE_ARGS` over config
+
+**Commit message:** `refactor(cmd): forward _GH_CLAUDE_ARGS to claude and extract model for ask-mode`
+
+---
+
+### Task 3: Simplify chat commands — remove `--` splitting for agent args — M — [x] Complete
+
+**What:** In `_gh_pr_chat`, `_gh_issue_chat`, and `_gh_run_chat`: remove the `_split_on_separator` call and `_extract_chat_passthrough` call. Parse subcommand args (resource ID, `-d`/`--description`) directly from `$@`. Extract `--session-id`/`--resume` from `_GH_CLAUDE_ARGS` using `_extract_claude_arg`. The `_cmd_chat` call simplifies to `_cmd_chat "$url" "$prompt" "${session_args[@]}"` — the `_GH_CLAUDE_ARGS` are forwarded by `_cmd_chat` internally. Delete `_extract_chat_passthrough` from `gh_cmd.sh` since no callers remain.
+
+**Files:**
+
+- Modify: `scripts/gh_pr.sh` — `_gh_pr_chat` (remove split/extract, use `_extract_claude_arg` for session)
+- Modify: `scripts/gh_issue.sh` — `_gh_issue_chat` (same)
+- Modify: `scripts/gh_run.sh` — `_gh_run_chat` (same)
+- Modify: `scripts/gh_cmd.sh` — delete `_extract_chat_passthrough`
+
+**Test strategy:** Test that chat commands work with session args in `_GH_CLAUDE_ARGS`. Test that `--resume` and `--session-id` are extracted correctly. Test that `_cmd_chat` is called with session args only (no leftover passthrough).
+
+**Acceptance criteria:**
+
+- [ ] `_GH_CLAUDE_ARGS=(--resume abc123)` is correctly extracted for session resolution
+- [ ] `_GH_CLAUDE_ARGS=(--session-id my-session)` is correctly extracted for session resolution
+- [ ] Chat commands no longer split on `--`
+- [ ] `_extract_chat_passthrough` is deleted from `gh_cmd.sh`
+
+**Commit message:** `refactor(chat): extract session args from _GH_CLAUDE_ARGS, remove -- splitting`
+
+---
+
+### Task 4: Update help text — S — [x] Complete
+
+**What:** Update all help functions to reflect the new arg placement. Remove `[-- AGENT_OPTIONS]` from chat command USAGE lines. Show agent flags before the subcommand in examples. Keep `[-- GH_*_OPTIONS]` in create/edit/comment/review help unchanged. Update the top-level `_show_help` to mention global flags.
+
+**Files:**
+
+- Modify: `gh-claude` — `_show_help`
+- Modify: `scripts/gh_pr.sh` — `_show_pr_chat_help`, `_show_pr_help`
+- Modify: `scripts/gh_issue.sh` — `_show_issue_chat_help`, `_show_issue_help`
+- Modify: `scripts/gh_run.sh` — `_show_run_chat_help`, `_show_run_help`
+
+**Test strategy:** Existing help tests check for key strings. Update assertions if output strings changed.
+
+**Acceptance criteria:**
+
+- [ ] Chat help shows `gh claude [AGENT_OPTIONS] pr chat [PR_NUMBER]` style usage
+- [ ] Chat help examples show `gh claude --model sonnet pr chat 42`
+- [ ] Non-chat help still shows `[-- GH_*_OPTIONS]` for gh passthrough
+- [ ] Top-level help mentions agent options placement
+
+**Commit message:** `docs(help): update usage examples for pre-subcommand agent args`
+
+---
+
+### Task 5: Update tests — L — [x] Complete
+
+**What:** Update `gh_pr_chat.bats`, `gh_issue_chat.bats`, `gh_run_chat.bats`: change all tests that pass claude args after `--` to set `_GH_CLAUDE_ARGS` instead. Remove `_extract_chat_passthrough` from the `declare -f` lists in test setup blocks. Add `_extract_claude_arg` to the `declare -f` lists. Add new tests in `gh_cmd.bats` for `_extract_claude_arg` helper. Add tests for `main()` arg collection (may need a new test file or integration-style tests).
+
+**Files:**
+
+- Modify: `tests/gh_pr_chat.bats` — update passthrough tests, setup blocks
+- Modify: `tests/gh_issue_chat.bats` — update passthrough tests, setup blocks
+- Modify: `tests/gh_run_chat.bats` — update passthrough tests, setup blocks
+- Modify: `tests/gh_cmd.bats` — add `_extract_claude_arg` tests
+
+**Test strategy:** Run full test suite (`bats tests/`). Verify all existing tests pass with modifications. New tests cover: `_extract_claude_arg` with various flag positions, `_GH_CLAUDE_ARGS` forwarding in `_cmd_chat`, session arg extraction from `_GH_CLAUDE_ARGS`.
+
+**Acceptance criteria:**
+
+- [ ] All existing bats tests pass (with updates)
+- [ ] `_extract_claude_arg` has unit tests for: flag present, flag absent, flag at different positions
+- [ ] Chat tests verify `_GH_CLAUDE_ARGS` forwarding works
+- [ ] No test references `_extract_chat_passthrough`
+
+**Commit message:** `test: update tests for pre-subcommand claude args`
+
+## Task Dependencies
+
+Task 1 → Tasks 2, 3 (both need the global array). Task 4 is independent. Task 5 depends on all others.
+
+Critical path: **Task 1 → Task 3 → Task 5**
+
+## Open Questions
+
+- Should `--effort` also be extracted and forwarded to `_cmd_ask` (prompt mode) alongside `--model`, or is `--model` the only relevant ask-mode override?
+
+## Dependencies & Blockers
+
+- None

--- a/gh-claude
+++ b/gh-claude
@@ -54,7 +54,7 @@ _show_help() {
 gh claude - AI-powered GitHub CLI extension
 
 USAGE:
-    gh claude <command> [subcommand] [options]
+    gh claude [CLAUDE_OPTIONS] <command> [subcommand] [options]
 
 COMMANDS:
     pr          Pull request operations (create, edit, review, explain, chat)
@@ -63,6 +63,17 @@ COMMANDS:
 
 FLAGS:
     -V, --version   Print version
+
+CLAUDE OPTIONS:
+    Options placed before the subcommand are forwarded to the claude binary.
+    For example: --model, --verbose, --resume, --session-id, --allowedTools,
+    --disallowedTools, --effort, --permission-mode, --mcp-config, etc.
+
+EXAMPLES:
+    gh claude pr chat 42
+    gh claude --model sonnet pr chat 42
+    gh claude --verbose --effort high issue chat 7
+    gh claude --resume <UUID> pr chat 42
 
 SEE ALSO:
     gh claude pr --help        # PR command help
@@ -80,6 +91,28 @@ _show_version() {
 
 # Main entry point
 main() {
+	# Collect claude agent args before the first subcommand keyword
+	_GH_CLAUDE_ARGS=()
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		pr | issue | run)
+			break
+			;;
+		--version | -V)
+			_show_version
+			return 0
+			;;
+		--help | -h | help)
+			_show_help
+			return 0
+			;;
+		*)
+			_GH_CLAUDE_ARGS+=("$1")
+			shift
+			;;
+		esac
+	done
+
 	local cmd="${1:-}"
 	shift || true
 
@@ -93,10 +126,7 @@ main() {
 	run)
 		_gh_run "$@"
 		;;
-	--version | -V)
-		_show_version
-		;;
-	--help | -h | help | "")
+	"")
 		_show_help
 		;;
 	*)

--- a/scripts/gh_cmd.sh
+++ b/scripts/gh_cmd.sh
@@ -35,18 +35,37 @@ _cmd_render() {
 }
 
 # Resolve the configured model for a given scope
-# Resolves: claude.<scope>.model → claude.model → haiku
+# Resolves: _GH_CLAUDE_ARGS --model → claude.<scope>.model → claude.model → haiku
 # Usage: _gh_config_claude_model [SCOPE]   (SCOPE: pr | issue | run | empty)
 _gh_config_claude_model() {
 	local scope="${1:-}"
 	local model=""
-	if [[ -n "$scope" ]]; then
+	model=$(_extract_claude_arg --model)
+	if [[ -z "$model" && -n "$scope" ]]; then
 		model=$(gh config get "claude.${scope}.model" 2>/dev/null || true)
 	fi
 	if [[ -z "$model" ]]; then
 		model=$(gh config get claude.model 2>/dev/null || true)
 	fi
 	printf '%s' "${model:-haiku}"
+}
+
+# Extract a flag's value from the _GH_CLAUDE_ARGS array.
+#
+# Scans _GH_CLAUDE_ARGS for a --flag followed by its value.
+# Prints the value to stdout if found; prints nothing otherwise.
+#
+# Usage: value=$(_extract_claude_arg --model)
+_extract_claude_arg() {
+	local _eca_flag="$1"
+	local _eca_i=0
+	while [[ $_eca_i -lt ${#_GH_CLAUDE_ARGS[@]} ]]; do
+		if [[ "${_GH_CLAUDE_ARGS[$_eca_i]}" == "$_eca_flag" ]] && ((_eca_i + 1 < ${#_GH_CLAUDE_ARGS[@]})); then
+			printf '%s' "${_GH_CLAUDE_ARGS[$((_eca_i + 1))]}"
+			return 0
+		fi
+		((++_eca_i))
+	done
 }
 
 # Send a prompt to Claude in non-interactive (prompt) mode
@@ -118,9 +137,9 @@ _cmd_chat() {
 	_trust_workspace "$(pwd -P)"
 
 	if [[ -n "$prompt" ]]; then
-		printf "%s" "$url" | claude --append-system-prompt "$prompt" "$@"
+		printf "%s" "$url" | claude --append-system-prompt "$prompt" "$@" "${_GH_CLAUDE_ARGS[@]}"
 	else
-		claude "$@"
+		claude "$@" "${_GH_CLAUDE_ARGS[@]}"
 	fi
 }
 
@@ -409,46 +428,6 @@ _parse_chat_args() {
 			;;
 		esac
 		((++_pca_i))
-	done
-}
-
-# Extract --session-id and --resume values from chat passthrough args.
-#
-# Scans the passthrough array and populates session_id_ref and resume_ref
-# with the corresponding values when found. Does not modify the array.
-#
-# Usage: _extract_chat_passthrough passthrough_ref session_id_ref resume_ref
-_extract_chat_passthrough() {
-	local -n _ecp_args="$1"
-	local -n _ecp_session_id="$2"
-	local -n _ecp_resume="$3"
-	local _ecp_i=0
-	local _ecp_skip=false
-
-	while [[ $_ecp_i -lt ${#_ecp_args[@]} ]]; do
-		if [[ "$_ecp_skip" = true ]]; then
-			_ecp_skip=false
-			((++_ecp_i))
-			continue
-		fi
-
-		case "${_ecp_args[$_ecp_i]}" in
-		--session-id)
-			if ((_ecp_i + 1 < ${#_ecp_args[@]})); then
-				# shellcheck disable=SC2034 # nameref: set by caller
-				_ecp_session_id="${_ecp_args[$((_ecp_i + 1))]}"
-				_ecp_skip=true
-			fi
-			;;
-		--resume)
-			if ((_ecp_i + 1 < ${#_ecp_args[@]})); then
-				# shellcheck disable=SC2034 # nameref: set by caller
-				_ecp_resume="${_ecp_args[$((_ecp_i + 1))]}"
-				_ecp_skip=true
-			fi
-			;;
-		esac
-		((++_ecp_i))
 	done
 }
 

--- a/scripts/gh_issue.sh
+++ b/scripts/gh_issue.sh
@@ -701,12 +701,12 @@ _show_issue_chat_help() {
 gh claude issue chat - Open an agent session with issue context
 
 USAGE:
-    gh claude issue chat <ISSUE_NUMBER> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] issue chat <ISSUE_NUMBER> [-d <DESCRIPTION>]
 
 DESCRIPTION:
     Fetches the GitHub issue metadata, renders it as context, and pipes
     it into the configured agent binary (default: claude).
-    Options after -- are passed directly to the agent binary.
+    Claude options (e.g. --model, --verbose) go before the subcommand.
 
     Configure the model: gh config set claude.issue.model <model>
 
@@ -717,9 +717,9 @@ EXAMPLES:
     gh claude issue chat 42
     gh claude issue chat https://github.com/owner/repo/issues/42
     gh claude issue chat 42 -d "focus on the auth module"
-    gh claude issue chat 42 -- --model sonnet
-    gh claude issue chat 42 -- --session-id <UUID>        # named session (reuses on next call)
-    gh claude issue chat 42 -- --resume <UUID>            # resume a specific session
+    gh claude --model sonnet issue chat 42
+    gh claude --session-id <UUID> issue chat 42            # named session
+    gh claude --resume <UUID> issue chat 42                # resume a session
 
 ENVIRONMENT:
     GH_CLAUDE_DEFAULT_SESSION_ID=<UUID>
@@ -743,16 +743,12 @@ _gh_issue_chat() {
 		;;
 	esac
 
-	local args=()
-	local passthrough=()
-	_split_on_separator args passthrough "$@"
-
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_claude_source_dir/templates/gh_issue_chat.tmpl"
 
 	local gh_issue_number="" gh_issue_description=""
-	_parse_issue_chat_args gh_issue_number gh_issue_description "${args[@]}"
+	_parse_issue_chat_args gh_issue_number gh_issue_description "$@"
 
 	if [[ -z "$gh_issue_number" ]]; then
 		gum log --level error "No issue number provided"
@@ -761,7 +757,8 @@ _gh_issue_chat() {
 	fi
 
 	local gh_issue_user_session_id="" gh_issue_user_resume=""
-	_extract_chat_passthrough passthrough gh_issue_user_session_id gh_issue_user_resume
+	gh_issue_user_session_id=$(_extract_claude_arg --session-id)
+	gh_issue_user_resume=$(_extract_claude_arg --resume)
 
 	local gh_issue_dir="" gh_issue_is_new_chat="" gh_issue_session_args=()
 	_resolve_chat_session "issue-$gh_issue_number" "$gh_issue_user_session_id" "$gh_issue_user_resume" gh_issue_dir gh_issue_is_new_chat gh_issue_session_args || return 1
@@ -786,7 +783,7 @@ _gh_issue_chat() {
 		)
 	fi
 
-	_cmd_chat "$gh_issue_url" "$gh_issue_prompt" "${gh_issue_session_args[@]}" "${passthrough[@]}"
+	_cmd_chat "$gh_issue_url" "$gh_issue_prompt" "${gh_issue_session_args[@]}"
 }
 
 # Issue help function
@@ -798,17 +795,18 @@ _show_issue_help() {
 gh claude issue - Issue commands with AI assistance
 
 USAGE:
-    gh claude issue create -d <DESCRIPTION> [-- GH_ISSUE_CREATE_OPTIONS]
-    gh claude issue edit <ISSUE_NUMBER|URL> -d <DESCRIPTION> [-- GH_ISSUE_EDIT_OPTIONS]
-    gh claude issue comment <ISSUE_NUMBER|URL> -d <DESCRIPTION> [-- GH_ISSUE_COMMENT_OPTIONS]
-    gh claude issue plan <ISSUE_NUMBER|URL> [-d <DESCRIPTION>]
-    gh claude issue chat <ISSUE_NUMBER|URL> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] issue create -d <DESCRIPTION> [-- GH_ISSUE_CREATE_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] issue edit <ISSUE_NUMBER|URL> -d <DESCRIPTION> [-- GH_ISSUE_EDIT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] issue comment <ISSUE_NUMBER|URL> -d <DESCRIPTION> [-- GH_ISSUE_COMMENT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] issue plan <ISSUE_NUMBER|URL> [-d <DESCRIPTION>]
+    gh claude [CLAUDE_OPTIONS] issue chat <ISSUE_NUMBER|URL> [-d <DESCRIPTION>]
 
 DESCRIPTION:
     Creates and edits GitHub issues with AI-generated titles and structured
     bodies. Posts AI-generated comments on existing issues. Generates
     implementation plans from issues and prints them to stdout.
     Opens agent sessions with issue context.
+    Claude options (e.g. --model) go before the subcommand.
 
 COMMANDS:
     create      Create issues with AI-generated content

--- a/scripts/gh_pr.sh
+++ b/scripts/gh_pr.sh
@@ -760,13 +760,13 @@ _show_pr_chat_help() {
 gh claude pr chat - Open an agent session with PR context
 
 USAGE:
-    gh claude pr chat [PR_NUMBER] [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] pr chat [PR_NUMBER] [-d <DESCRIPTION>]
 
 DESCRIPTION:
     Fetches the GitHub PR metadata and diff, renders it as context, and
     pipes it into the configured agent binary (default: claude).
     Auto-detects PR from the current branch if no number is provided.
-    Options after -- are passed directly to the agent binary.
+    Claude options (e.g. --model, --verbose) go before the subcommand.
 
     Configure the model: gh config set claude.pr.model <model>
 
@@ -776,10 +776,10 @@ FLAGS:
 EXAMPLES:
     gh claude pr chat 42
     gh claude pr chat -d "focus on the security changes"
-    gh claude pr chat                          # auto-detect PR from current branch
-    gh claude pr chat 42 -- --model sonnet
-    gh claude pr chat 42 -- --session-id <UUID>       # named session (reuses on next call)
-    gh claude pr chat 42 -- --resume <UUID>           # resume a specific session
+    gh claude pr chat                                     # auto-detect PR
+    gh claude --model sonnet pr chat 42
+    gh claude --session-id <UUID> pr chat 42              # named session
+    gh claude --resume <UUID> pr chat 42                  # resume a session
 
 ENVIRONMENT:
     GH_CLAUDE_DEFAULT_SESSION_ID=<UUID>
@@ -803,16 +803,12 @@ _gh_pr_chat() {
 		;;
 	esac
 
-	local args=()
-	local passthrough=()
-	_split_on_separator args passthrough "$@"
-
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_claude_source_dir/templates/gh_pr_chat.tmpl"
 
 	local gh_pr_number="" gh_pr_description=""
-	_parse_pr_chat_args gh_pr_number gh_pr_description "${args[@]}"
+	_parse_pr_chat_args gh_pr_number gh_pr_description "$@"
 
 	if [[ -z "$gh_pr_number" ]]; then
 		gh_pr_number=$(_detect_pr_number)
@@ -825,7 +821,8 @@ _gh_pr_chat() {
 	fi
 
 	local gh_pr_user_session_id="" gh_pr_user_resume=""
-	_extract_chat_passthrough passthrough gh_pr_user_session_id gh_pr_user_resume
+	gh_pr_user_session_id=$(_extract_claude_arg --session-id)
+	gh_pr_user_resume=$(_extract_claude_arg --resume)
 
 	local gh_pr_dir="" gh_pr_is_new_chat="" gh_pr_session_args=()
 	_resolve_chat_session "pull-$gh_pr_number" "$gh_pr_user_session_id" "$gh_pr_user_resume" gh_pr_dir gh_pr_is_new_chat gh_pr_session_args || return 1
@@ -856,7 +853,7 @@ _gh_pr_chat() {
 		)
 	fi
 
-	_cmd_chat "$gh_pr_url" "$gh_pr_prompt" "${gh_pr_session_args[@]}" "${passthrough[@]}"
+	_cmd_chat "$gh_pr_url" "$gh_pr_prompt" "${gh_pr_session_args[@]}"
 }
 
 # Parse PR comment arguments (before -- separator).
@@ -1014,16 +1011,17 @@ _show_pr_help() {
 gh claude pr - Pull request commands with AI assistance
 
 USAGE:
-    gh claude pr create [-d <DESCRIPTION>] [-B <BASE>] [-- GH_PR_CREATE_OPTIONS]
-    gh claude pr edit [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_EDIT_OPTIONS]
-    gh claude pr review [PR_NUMBER] [-d <DESCRIPTION>] [-- GH_PR_REVIEW_OPTIONS]
-    gh claude pr explain [PR_NUMBER]
-    gh claude pr chat [PR_NUMBER] [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
-    gh claude pr comment [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_COMMENT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] pr create [-d <DESCRIPTION>] [-B <BASE>] [-- GH_PR_CREATE_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] pr edit [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_EDIT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] pr review [PR_NUMBER] [-d <DESCRIPTION>] [-- GH_PR_REVIEW_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] pr explain [PR_NUMBER]
+    gh claude [CLAUDE_OPTIONS] pr chat [PR_NUMBER] [-d <DESCRIPTION>]
+    gh claude [CLAUDE_OPTIONS] pr comment [PR_NUMBER] -d <DESCRIPTION> [-- GH_PR_COMMENT_OPTIONS]
 
 DESCRIPTION:
     Creates, edits, reviews, explains, and comments on GitHub pull requests
     with AI-generated content. Opens agent sessions with PR context.
+    Claude options (e.g. --model) go before the subcommand.
 
 COMMANDS:
     create      Create PRs with AI-generated titles and descriptions

--- a/scripts/gh_run.sh
+++ b/scripts/gh_run.sh
@@ -204,13 +204,13 @@ _show_run_chat_help() {
 gh claude run chat - Open an agent session with workflow run context
 
 USAGE:
-    gh claude run chat <RUN_ID> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] run chat <RUN_ID> [-d <DESCRIPTION>]
 
 DESCRIPTION:
     Fetches the GitHub Actions workflow run metadata and logs, renders
     it as context, and pipes it into the configured agent binary
     (default: claude).
-    Options after -- are passed directly to the agent binary.
+    Claude options (e.g. --model, --verbose) go before the subcommand.
 
     Configure the model: gh config set claude.run.model <model>
 
@@ -220,9 +220,9 @@ FLAGS:
 EXAMPLES:
     gh claude run chat 123456
     gh claude run chat 123456 -d "focus on test failures"
-    gh claude run chat 123456 -- --model sonnet
-    gh claude run chat 123456 -- --session-id <UUID>    # named session (reuses on next call)
-    gh claude run chat 123456 -- --resume <UUID>        # resume a specific session
+    gh claude --model sonnet run chat 123456
+    gh claude --session-id <UUID> run chat 123456       # named session
+    gh claude --resume <UUID> run chat 123456           # resume a session
 
 ENVIRONMENT:
     GH_CLAUDE_DEFAULT_SESSION_ID=<UUID>
@@ -246,16 +246,12 @@ _gh_run_chat() {
 		;;
 	esac
 
-	local args=()
-	local passthrough=()
-	_split_on_separator args passthrough "$@"
-
 	local template_file
 	# shellcheck disable=SC2154
 	template_file="$_gh_claude_source_dir/templates/gh_run_chat.tmpl"
 
 	local gh_run_id="" gh_run_description=""
-	_parse_run_chat_args gh_run_id gh_run_description "${args[@]}"
+	_parse_run_chat_args gh_run_id gh_run_description "$@"
 
 	if [[ -z "$gh_run_id" ]]; then
 		gum log --level error "No run ID provided"
@@ -269,7 +265,8 @@ _gh_run_chat() {
 	fi
 
 	local gh_run_user_session_id="" gh_run_user_resume=""
-	_extract_chat_passthrough passthrough gh_run_user_session_id gh_run_user_resume
+	gh_run_user_session_id=$(_extract_claude_arg --session-id)
+	gh_run_user_resume=$(_extract_claude_arg --resume)
 
 	local gh_run_dir="" gh_run_is_new_chat="" gh_run_session_args=()
 	_resolve_chat_session "run-$gh_run_id" "$gh_run_user_session_id" "$gh_run_user_resume" gh_run_dir gh_run_is_new_chat gh_run_session_args || return 1
@@ -292,7 +289,7 @@ _gh_run_chat() {
 		)
 	fi
 
-	_cmd_chat "$gh_run_url" "$gh_run_prompt" "${gh_run_session_args[@]}" "${passthrough[@]}"
+	_cmd_chat "$gh_run_url" "$gh_run_prompt" "${gh_run_session_args[@]}"
 }
 
 # Run help function
@@ -304,12 +301,13 @@ _show_run_help() {
 gh claude run - Workflow run commands with AI assistance
 
 USAGE:
-    gh claude run explain <RUN_ID>
-    gh claude run chat <RUN_ID> [-d <DESCRIPTION>] [-- AGENT_OPTIONS]
+    gh claude [CLAUDE_OPTIONS] run explain <RUN_ID>
+    gh claude [CLAUDE_OPTIONS] run chat <RUN_ID> [-d <DESCRIPTION>]
 
 DESCRIPTION:
     Analyzes GitHub Actions workflow runs and explains what happened.
     Opens agent sessions with run context.
+    Claude options (e.g. --model) go before the subcommand.
 
 COMMANDS:
     explain     Analyze a workflow run and explain failures

--- a/tests/gh_cmd.bats
+++ b/tests/gh_cmd.bats
@@ -10,6 +10,9 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
 setup() {
 	export _gh_claude_source_dir="$REPO_ROOT"
 
+	# Initialize global claude args array (set per-test when needed)
+	_GH_CLAUDE_ARGS=()
+
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
 	git() { echo ""; }
@@ -23,7 +26,7 @@ setup() {
 		printf '_gh_cmd_dir=%q\n' "$_gh_cmd_dir"
 		declare -f _split_on_separator _cmd_render _parse_title _parse_body \
 			_gh_repo_name _git_repo_path _git_branch_diff _trust_workspace \
-			_gh_config_claude_model
+			_gh_config_claude_model _extract_claude_arg
 	)"
 }
 
@@ -529,4 +532,62 @@ Actual body.")
 	output=$(_gh_config_claude_model "pr")
 
 	[[ "$output" == "haiku" ]]
+}
+
+@test "_gh_config_claude_model: _GH_CLAUDE_ARGS --model overrides config" {
+	gh() { echo "sonnet"; }
+	export -f gh
+
+	_GH_CLAUDE_ARGS=(--model opus)
+	local output
+	output=$(_gh_config_claude_model "pr")
+
+	[[ "$output" == "opus" ]]
+}
+
+@test "_gh_config_claude_model: falls back to config when _GH_CLAUDE_ARGS has no --model" {
+	gh() { echo "sonnet"; }
+	export -f gh
+
+	_GH_CLAUDE_ARGS=(--verbose)
+	local output
+	output=$(_gh_config_claude_model)
+
+	[[ "$output" == "sonnet" ]]
+}
+
+# ---------------------------------------------------------------------------
+# _extract_claude_arg
+# ---------------------------------------------------------------------------
+
+@test "_extract_claude_arg: returns value for present flag" {
+	_GH_CLAUDE_ARGS=(--model sonnet)
+	local output
+	output=$(_extract_claude_arg --model)
+
+	[[ "$output" == "sonnet" ]]
+}
+
+@test "_extract_claude_arg: returns empty for absent flag" {
+	_GH_CLAUDE_ARGS=(--verbose)
+	local output
+	output=$(_extract_claude_arg --model)
+
+	[[ -z "$output" ]]
+}
+
+@test "_extract_claude_arg: returns empty with empty array" {
+	_GH_CLAUDE_ARGS=()
+	local output
+	output=$(_extract_claude_arg --model)
+
+	[[ -z "$output" ]]
+}
+
+@test "_extract_claude_arg: handles flag at end without value" {
+	_GH_CLAUDE_ARGS=(--model)
+	local output
+	output=$(_extract_claude_arg --model)
+
+	[[ -z "$output" ]]
 }

--- a/tests/gh_issue_chat.bats
+++ b/tests/gh_issue_chat.bats
@@ -12,6 +12,9 @@ setup() {
 	export HOME="$BATS_TEST_TMPDIR"
 	unset XDG_STATE_HOME
 
+	# Initialize global claude args array (set per-test when needed)
+	_GH_CLAUDE_ARGS=()
+
 	mkdir -p "$BATS_TEST_TMPDIR/.git"
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
@@ -31,8 +34,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_issue.sh"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _extract_issue_number _parse_chat_args _parse_issue_chat_args _extract_chat_passthrough _show_issue_chat_help _gh_issue_chat \
-			_cmd_chat _cmd_render _split_on_separator _get_agent _git_repo_path _resolve_chat_session \
+		declare -f _extract_issue_number _parse_chat_args _parse_issue_chat_args _extract_claude_arg _show_issue_chat_help _gh_issue_chat \
+			_cmd_chat _cmd_render _get_agent _git_repo_path _resolve_chat_session \
 			_prepare_issue_chat_context _prepare_issue_context _resolve_context_dir _create_context_dir _save_context_file \
 			_gh_session_base_dir _uuidgen
 	)"
@@ -211,7 +214,7 @@ _setup_chat_mocks() {
 	[[ "$status" -eq 1 ]]
 }
 
-@test "_gh_issue_chat: resumes session when -- --resume is passed" {
+@test "_gh_issue_chat: resumes session when --resume is in _GH_CLAUDE_ARGS" {
 	_setup_chat_mocks
 
 	# Create a valid session dir so --resume finds it
@@ -226,10 +229,10 @@ _setup_chat_mocks() {
 		printf 'ARGS:%s\n' "$*"
 	}
 
-	run _gh_issue_chat 42 -- --resume abc123
+	_GH_CLAUDE_ARGS=(--resume abc123)
+	run _gh_issue_chat 42
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--resume"* ]]
 	# No prompt rendered on resume
 	[[ "$output" != *"Test Issue"* ]]
 }
@@ -245,7 +248,21 @@ _setup_chat_mocks() {
 # Passthrough parsing and forwarding
 # ---------------------------------------------------------------------------
 
-@test "_gh_issue_chat: forwards passthrough args to _cmd_chat" {
+@test "_gh_issue_chat: forwards _GH_CLAUDE_ARGS to _cmd_chat via claude" {
+	_setup_chat_mocks
+
+	# Mock claude to capture args
+	claude() { printf 'CLAUDE_ARGS:%s\n' "$*"; }
+	export -f claude
+
+	_GH_CLAUDE_ARGS=(--model sonnet --verbose)
+	run _gh_issue_chat 42
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--model sonnet --verbose"* ]]
+}
+
+@test "_gh_issue_chat: accepts --session-id in _GH_CLAUDE_ARGS for new session" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
@@ -255,23 +272,13 @@ _setup_chat_mocks() {
 		printf 'ARGS:%s\n' "$*"
 	}
 
-	run _gh_issue_chat 42 -- --model sonnet --verbose
+	_GH_CLAUDE_ARGS=(--session-id my-session)
+	run _gh_issue_chat 42
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--model sonnet --verbose"* ]]
-}
-
-@test "_gh_issue_chat: accepts --session-id in passthrough" {
-	_setup_chat_mocks
-
-	_cmd_chat() {
-		printf 'URL:%s\n' "$1"
-		shift 2
-		printf 'ARGS:%s\n' "$*"
-	}
-
-	run _gh_issue_chat 42 -- --session-id my-session
-
-	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--session-id my-session"* ]]
+	# New session should render prompt
+	[[ "$output" == *"PROMPT:"* ]]
+	# Session dir should have been created
+	local base="$BATS_TEST_TMPDIR/.local/state/gh/claude/sessions"
+	[[ -d "$base/my-session" ]]
 }

--- a/tests/gh_pr_chat.bats
+++ b/tests/gh_pr_chat.bats
@@ -12,6 +12,9 @@ setup() {
 	export HOME="$BATS_TEST_TMPDIR"
 	unset XDG_STATE_HOME
 
+	# Initialize global claude args array (set per-test when needed)
+	_GH_CLAUDE_ARGS=()
+
 	mkdir -p "$BATS_TEST_TMPDIR/.git"
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
@@ -31,8 +34,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		# shellcheck source=../scripts/gh_pr.sh
 		source "$REPO_ROOT/scripts/gh_pr.sh"
-		declare -f _extract_pr_number _parse_chat_args _parse_pr_chat_args _extract_chat_passthrough _show_pr_chat_help _gh_pr_chat _detect_pr_number \
-			_cmd_chat _cmd_render _split_on_separator _get_agent _git_repo_path _resolve_chat_session \
+		declare -f _extract_pr_number _parse_chat_args _parse_pr_chat_args _extract_claude_arg _show_pr_chat_help _gh_pr_chat _detect_pr_number \
+			_cmd_chat _cmd_render _get_agent _git_repo_path _resolve_chat_session \
 			_prepare_pr_chat_context _prepare_pr_diff_context _resolve_context_dir _create_context_dir _save_context_file \
 			_gh_session_base_dir _uuidgen
 	)"
@@ -260,7 +263,7 @@ _setup_chat_mocks() {
 	[[ "$status" -eq 1 ]]
 }
 
-@test "_gh_pr_chat: resumes session when -- --resume is passed" {
+@test "_gh_pr_chat: resumes session when --resume is in _GH_CLAUDE_ARGS" {
 	_setup_chat_mocks
 
 	# Create a valid session dir so --resume finds it
@@ -276,15 +279,15 @@ _setup_chat_mocks() {
 	}
 	export -f _cmd_chat
 
-	run _gh_pr_chat 42 -- --resume abc123
+	_GH_CLAUDE_ARGS=(--resume abc123)
+	run _gh_pr_chat 42
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--resume"* ]]
 	# No prompt rendered on resume
 	[[ "$output" != *"Test PR Title"* ]]
 }
 
-@test "_gh_pr_chat: resumes session when -- --session-id is reused" {
+@test "_gh_pr_chat: resumes session when --session-id is in _GH_CLAUDE_ARGS and dir exists" {
 	_setup_chat_mocks
 
 	# Pre-create session dir so --session-id triggers resume (is_new="")
@@ -300,10 +303,10 @@ _setup_chat_mocks() {
 	}
 	export -f _cmd_chat
 
-	run _gh_pr_chat 42 -- --session-id my-review
+	_GH_CLAUDE_ARGS=(--session-id my-review)
+	run _gh_pr_chat 42
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--session-id my-review"* ]]
 	# No prompt rendered on resume
 	[[ "$output" != *"Test PR Title"* ]]
 }
@@ -319,7 +322,21 @@ _setup_chat_mocks() {
 # Passthrough parsing and forwarding
 # ---------------------------------------------------------------------------
 
-@test "_gh_pr_chat: forwards passthrough args to _cmd_chat" {
+@test "_gh_pr_chat: forwards _GH_CLAUDE_ARGS to _cmd_chat via claude" {
+	_setup_chat_mocks
+
+	# Mock claude to capture args
+	claude() { printf 'CLAUDE_ARGS:%s\n' "$*"; }
+	export -f claude
+
+	_GH_CLAUDE_ARGS=(--model sonnet --verbose)
+	run _gh_pr_chat 42
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--model sonnet --verbose"* ]]
+}
+
+@test "_gh_pr_chat: accepts --session-id in _GH_CLAUDE_ARGS for new session" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
@@ -330,24 +347,13 @@ _setup_chat_mocks() {
 	}
 	export -f _cmd_chat
 
-	run _gh_pr_chat 42 -- --model sonnet --verbose
+	_GH_CLAUDE_ARGS=(--session-id my-review)
+	run _gh_pr_chat 42
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--model sonnet --verbose"* ]]
-}
-
-@test "_gh_pr_chat: accepts --session-id in passthrough for new session" {
-	_setup_chat_mocks
-
-	_cmd_chat() {
-		printf 'URL:%s\n' "$1"
-		shift 2
-		printf 'ARGS:%s\n' "$*"
-	}
-	export -f _cmd_chat
-
-	run _gh_pr_chat 42 -- --session-id my-review
-
-	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--session-id my-review"* ]]
+	# New session should render prompt
+	[[ "$output" == *"PROMPT:"* ]]
+	# Session dir should have been created
+	local base="$BATS_TEST_TMPDIR/.local/state/gh/claude/sessions"
+	[[ -d "$base/my-review" ]]
 }

--- a/tests/gh_run_chat.bats
+++ b/tests/gh_run_chat.bats
@@ -12,6 +12,9 @@ setup() {
 	export HOME="$BATS_TEST_TMPDIR"
 	unset XDG_STATE_HOME
 
+	# Initialize global claude args array (set per-test when needed)
+	_GH_CLAUDE_ARGS=()
+
 	mkdir -p "$BATS_TEST_TMPDIR/.git"
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	gh() { echo ""; }
@@ -31,8 +34,8 @@ setup() {
 		source "$REPO_ROOT/scripts/gh_run.sh"
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
-		declare -f _parse_chat_args _parse_run_chat_args _extract_chat_passthrough _show_run_chat_help _gh_run_chat \
-			_cmd_chat _cmd_render _split_on_separator _get_agent _git_repo_path _resolve_chat_session \
+		declare -f _parse_chat_args _parse_run_chat_args _extract_claude_arg _show_run_chat_help _gh_run_chat \
+			_cmd_chat _cmd_render _get_agent _git_repo_path _resolve_chat_session \
 			_prepare_run_chat_context _prepare_run_context _resolve_context_dir _create_context_dir _save_context_file \
 			_parse_run_args _gh_session_base_dir _uuidgen
 	)"
@@ -218,7 +221,7 @@ _setup_chat_mocks() {
 	[[ "$status" -eq 1 ]]
 }
 
-@test "_gh_run_chat: resumes session when -- --resume is passed" {
+@test "_gh_run_chat: resumes session when --resume is in _GH_CLAUDE_ARGS" {
 	_setup_chat_mocks
 
 	# Create a valid session dir so --resume finds it
@@ -233,10 +236,10 @@ _setup_chat_mocks() {
 		printf 'ARGS:%s\n' "$*"
 	}
 
-	run _gh_run_chat 12345678 -- --resume abc123
+	_GH_CLAUDE_ARGS=(--resume abc123)
+	run _gh_run_chat 12345678
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--resume"* ]]
 	# No prompt rendered on resume
 	[[ "$output" != *"Test Run"* ]]
 }
@@ -252,7 +255,21 @@ _setup_chat_mocks() {
 # Passthrough parsing and forwarding
 # ---------------------------------------------------------------------------
 
-@test "_gh_run_chat: forwards passthrough args to _cmd_chat" {
+@test "_gh_run_chat: forwards _GH_CLAUDE_ARGS to _cmd_chat via claude" {
+	_setup_chat_mocks
+
+	# Mock claude to capture args
+	claude() { printf 'CLAUDE_ARGS:%s\n' "$*"; }
+	export -f claude
+
+	_GH_CLAUDE_ARGS=(--model sonnet --verbose)
+	run _gh_run_chat 12345678
+
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *"--model sonnet --verbose"* ]]
+}
+
+@test "_gh_run_chat: accepts --session-id in _GH_CLAUDE_ARGS for new session" {
 	_setup_chat_mocks
 
 	_cmd_chat() {
@@ -262,23 +279,13 @@ _setup_chat_mocks() {
 		printf 'ARGS:%s\n' "$*"
 	}
 
-	run _gh_run_chat 12345678 -- --model sonnet --verbose
+	_GH_CLAUDE_ARGS=(--session-id my-run)
+	run _gh_run_chat 12345678
 
 	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--model sonnet --verbose"* ]]
-}
-
-@test "_gh_run_chat: accepts --session-id in passthrough" {
-	_setup_chat_mocks
-
-	_cmd_chat() {
-		printf 'URL:%s\n' "$1"
-		shift 2
-		printf 'ARGS:%s\n' "$*"
-	}
-
-	run _gh_run_chat 12345678 -- --session-id my-run
-
-	[[ "$status" -eq 0 ]]
-	[[ "$output" == *"--session-id my-run"* ]]
+	# New session should render prompt
+	[[ "$output" == *"PROMPT:"* ]]
+	# Session dir should have been created
+	local base="$BATS_TEST_TMPDIR/.local/state/gh/claude/sessions"
+	[[ -d "$base/my-run" ]]
 }

--- a/tests/gh_session.bats
+++ b/tests/gh_session.bats
@@ -12,6 +12,9 @@ setup() {
 	export HOME="$BATS_TEST_TMPDIR"
 	unset XDG_STATE_HOME
 
+	# Initialize global claude args array (set per-test when needed)
+	_GH_CLAUDE_ARGS=()
+
 	gum() { if [[ "$1" == "log" ]]; then shift; shift; shift; echo "$@"; fi; }
 	git() {
 		case "$1 $2" in
@@ -28,7 +31,7 @@ setup() {
 		# shellcheck source=../scripts/gh_cmd.sh
 		source "$REPO_ROOT/scripts/gh_cmd.sh"
 		declare -f _git_repo_path _resolve_chat_session _gh_session_base_dir \
-			_extract_chat_passthrough _resolve_context_dir _create_context_dir \
+			_extract_claude_arg _resolve_context_dir _create_context_dir \
 			_uuidgen
 	)"
 }
@@ -200,32 +203,55 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
-# _extract_chat_passthrough
+# _extract_claude_arg
 # ---------------------------------------------------------------------------
 
-@test "_extract_chat_passthrough: extracts --session-id value" {
-	local pt=(--session-id my-session --verbose)
-	local sid="" resume=""
-	_extract_chat_passthrough pt sid resume
+@test "_extract_claude_arg: extracts --session-id value" {
+	_GH_CLAUDE_ARGS=(--session-id my-session --verbose)
+	local result
+	result=$(_extract_claude_arg --session-id)
 
-	[[ "$sid" == "my-session" ]]
+	[[ "$result" == "my-session" ]]
 }
 
-@test "_extract_chat_passthrough: extracts --resume value" {
-	local pt=(--resume abc123 --verbose)
-	local sid="" resume=""
-	_extract_chat_passthrough pt sid resume
+@test "_extract_claude_arg: extracts --resume value" {
+	_GH_CLAUDE_ARGS=(--resume abc123 --verbose)
+	local result
+	result=$(_extract_claude_arg --resume)
 
-	[[ "$resume" == "abc123" ]]
+	[[ "$result" == "abc123" ]]
 }
 
-@test "_extract_chat_passthrough: leaves refs empty when flags absent" {
-	local pt=(--model sonnet --verbose)
-	local sid="" resume=""
-	_extract_chat_passthrough pt sid resume
+@test "_extract_claude_arg: returns empty when flag absent" {
+	_GH_CLAUDE_ARGS=(--model sonnet --verbose)
+	local result
+	result=$(_extract_claude_arg --resume)
 
-	[[ -z "$sid" ]]
-	[[ -z "$resume" ]]
+	[[ -z "$result" ]]
+}
+
+@test "_extract_claude_arg: extracts --model value" {
+	_GH_CLAUDE_ARGS=(--model sonnet)
+	local result
+	result=$(_extract_claude_arg --model)
+
+	[[ "$result" == "sonnet" ]]
+}
+
+@test "_extract_claude_arg: returns empty with empty _GH_CLAUDE_ARGS" {
+	_GH_CLAUDE_ARGS=()
+	local result
+	result=$(_extract_claude_arg --model)
+
+	[[ -z "$result" ]]
+}
+
+@test "_extract_claude_arg: extracts value when flag is not first" {
+	_GH_CLAUDE_ARGS=(--verbose --effort high --model opus)
+	local result
+	result=$(_extract_claude_arg --model)
+
+	[[ "$result" == "opus" ]]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Move claude agent args (like `--model`, `--session-id`, `--resume`, `--verbose`) before the subcommand keyword instead of requiring a `--` separator after it.

**Before:**
```
gh claude pr chat 42 -- --model sonnet --verbose
```

**After:**
```
gh claude --model sonnet --verbose pr chat 42
```

The `--` separator is retained only for `gh` CLI passthrough args in create/edit/comment/review commands.

## Changes

- **`gh-claude`**: Add pre-subcommand arg collection loop in `main()` — collects all args before `pr`/`issue`/`run` into `_GH_CLAUDE_ARGS` array
- **`scripts/gh_cmd.sh`**: Add `_extract_claude_arg` helper; update `_cmd_chat` to forward `_GH_CLAUDE_ARGS`; update `_gh_config_claude_model` to check `_GH_CLAUDE_ARGS --model` first; delete `_extract_chat_passthrough`
- **`scripts/gh_pr.sh`**: Simplify `_gh_pr_chat` — use `_extract_claude_arg` for `--session-id`/`--resume`; update help text
- **`scripts/gh_issue.sh`**: Simplify `_gh_issue_chat` — same pattern; update help text
- **`scripts/gh_run.sh`**: Simplify `_gh_run_chat` — same pattern; update help text
- **Tests**: Update all chat/session/cmd tests for new `_GH_CLAUDE_ARGS` pattern (299 tests passing)

## Plan

See [`.github/claude/plans/86-claude-args-before-subcommand.md`](https://github.com/gh-extensions/gh-claude/blob/86/claude-args-before-subcommand/.github/claude/plans/86-claude-args-before-subcommand.md) for the full execution plan.

## Status

- [x] Task 1: Collect claude args in `main()`
- [x] Task 2: Forward `_GH_CLAUDE_ARGS` in `_cmd_chat` and extract model for ask-mode
- [x] Task 3: Simplify chat commands — remove `--` splitting for agent args
- [x] Task 4: Update help text
- [x] Task 5: Update tests

## Breaking Change

This is a breaking change. The `--` separator for claude agent args is no longer supported. Users must place agent flags before the subcommand keyword.

Closes #86